### PR TITLE
Ensure ~/.drenv subdirectories are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Commands:
 
 ### `drenv setup`
 
-This command will move the executable to your home directory and show instructions on how to add it to your `$PATH`.
+This command will move the executable to your home directory and show
+instructions on how to add it to your `$PATH`.
 
 This allows you to call `drenv` from anywhere in your terminal.
 
@@ -73,10 +74,12 @@ installation into the new project directory.
 
 ### `drenv local [version]`
 
-This command will update your current directory's DragonRuby version to the specified version.
+This command will update your current directory's DragonRuby version to the
+specified version.
 
 Under the hood, all **drenv** does is copy the contents of the global DragonRuby
-installation into the current project directory, excluding the `mygame` directory.
+installation into the current project directory, excluding the `mygame`
+directory.
 
 ### `drenv versions`
 

--- a/commands/global.ts
+++ b/commands/global.ts
@@ -1,5 +1,7 @@
 import { exists } from "jsr:@std/fs";
 
+import { homePath, versionsPath } from "../constants.ts";
+
 export class NotInstalled extends Error {
   version: string;
 
@@ -27,22 +29,17 @@ export default async function global(version: string | undefined = undefined) {
 }
 
 const setGlobalVersion = async (version: string) => {
-  if (!await exists(`${Deno.env.get("HOME")}/.drenv/versions/${version}`)) {
+  if (!await exists(`${versionsPath}/${version}`)) {
     throw new NotInstalled(version);
   }
 
-  return Deno.writeTextFile(
-    `${Deno.env.get("HOME")}/.drenv/.dragonruby-version`,
-    version,
-  );
+  return Deno.writeTextFile(`${homePath}/.dragonruby-version`, version);
 };
 
 const getGlobalVersion = async () => {
-  if (!await exists(`${Deno.env.get("HOME")}/.drenv/.dragonruby-version`)) {
+  if (!await exists(`${homePath}/.dragonruby-version`)) {
     throw new NoGlobalVersion();
   }
 
-  return Deno.readTextFile(
-    `${Deno.env.get("HOME")}/.drenv/.dragonruby-version`,
-  );
+  return Deno.readTextFile(`${homePath}/.dragonruby-version`);
 };

--- a/commands/local.ts
+++ b/commands/local.ts
@@ -1,6 +1,7 @@
 import { copy, exists } from "jsr:@std/fs";
 
 import { readVersion } from "../utils/read-version.ts";
+import { versionsPath } from "../constants.ts";
 
 export class NotInstalled extends Error {
   version: string;
@@ -22,7 +23,7 @@ export default async function local(version: string | undefined = undefined) {
 }
 
 const setLocalVersion = async (version: string) => {
-  const sourceDirectory = `${Deno.env.get("HOME")}/.drenv/versions/${version}`;
+  const sourceDirectory = `${versionsPath}/${version}`;
 
   if (!await exists(sourceDirectory)) {
     throw new NotInstalled(version);

--- a/commands/new.ts
+++ b/commands/new.ts
@@ -1,12 +1,9 @@
 import { copy } from "jsr:@std/fs";
 
-import { readVersion } from "../utils/read-version.ts";
+import { versionsPath } from "../constants.ts";
 
 import global from "./global.ts";
 
 export default async function newCommand(name: string) {
-  return copy(
-    `${Deno.env.get("HOME")}/.drenv/versions/${await global()}`,
-    name,
-  );
+  return copy(`${versionsPath}/${await global()}`, name);
 }

--- a/commands/register.ts
+++ b/commands/register.ts
@@ -1,6 +1,7 @@
-import { move } from "jsr:@std/fs";
+import { ensureDir, move } from "jsr:@std/fs";
 
 import { readVersion } from "../utils/read-version.ts";
+import { versionsPath } from "../constants.ts";
 
 export default async function register(path: string) {
   // TODO: Validate that directory is a DragonRuby installation
@@ -11,5 +12,7 @@ export default async function register(path: string) {
     throw new Error("drenv: DragonRuby installation is missing version");
   }
 
-  return move(path, `${Deno.env.get("HOME")}/.drenv/versions/${version}`);
+  await ensureDir(versionsPath);
+
+  return move(path, `${versionsPath}/${version}`);
 }

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -1,25 +1,31 @@
-import { exists, move } from "jsr:@std/fs";
+import { ensureDir, exists, move } from "jsr:@std/fs";
+
+import { binPath, shell } from "../constants.ts";
 
 export default async function setup() {
-  const binPath = `${Deno.env.get("HOME")}/.drenv/bin/drenv`;
-  const shell = Deno.env.get("SHELL");
+  const drenvPath = `${binPath}/drenv`;
 
   if (await exists(binPath)) {
     return "drenv: already installed";
   } else {
     if (!Deno.execPath().includes("drenv")) {
-      return "drenv: this command must be run from the drenv executable"
+      return "drenv: this command must be run from the drenv executable";
     }
 
-    await move(Deno.execPath(), binPath);
+    await ensureDir(binPath);
+    await move(Deno.execPath(), drenvPath);
 
-    console.log(`Installed at ${binPath}\n`);
+    console.log(`Installed at ${drenvPath}\n`);
     console.log(`Run the following to add drenv to your shell profile:\n`);
 
     if (shell?.includes("zsh")) {
-      console.log(`echo 'export PATH="$HOME/.drenv/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc`);
+      console.log(
+        `echo 'export PATH="$HOME/.drenv/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc`,
+      );
     } else if (shell?.includes("bash")) {
-      console.log(`echo 'export PATH="$HOME/.drenv/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc`);
+      console.log(
+        `echo 'export PATH="$HOME/.drenv/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc`,
+      );
     }
   }
 }

--- a/commands/versions.ts
+++ b/commands/versions.ts
@@ -1,9 +1,8 @@
 import { readVersion } from "../utils/read-version.ts";
+import { versionsPath } from "../constants.ts";
 
 export default async function versions() {
-  const directories = await Deno.readDir(
-    `${Deno.env.get("HOME")}/.drenv/versions/`,
-  );
+  const directories = await Deno.readDir(versionsPath);
 
   const currentVersion = await readVersion("./CHANGELOG-CURR.txt");
 

--- a/constants.ts
+++ b/constants.ts
@@ -1,0 +1,4 @@
+export const homePath = `${Deno.env.get("HOME")}/.drenv`;
+export const versionsPath = `${homePath}/versions`;
+export const binPath = `${homePath}/bin`;
+export const shell = Deno.env.get("SHELL");

--- a/main.ts
+++ b/main.ts
@@ -25,7 +25,7 @@ const actionRunner = (fn: (...args: any[]) => Promise<any>) => {
 program
   .name("drenv")
   .description("CLI to manage DragonRuby environments.")
-  .version("0.2.2");
+  .version("0.2.3");
 
 program.command("setup")
   .description("Setup your shell profile to use drenv.")


### PR DESCRIPTION
Also introduce a constants file to keep reference of cross-command constants, such as important `drenv` paths.

Fixes #1 and #2.