### PR TITLE
RFC - Add Indie and Pro license 'install' commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ deno compile --allow-read --allow-write --allow-env --output=builds/drenv --targ
 ```
 
 > [!NOTE]
-> Once **drenv** has been installed, you can seamlessly update to the latest version by running `drenv upgrade`.
+> Once **drenv** has been installed, you can seamlessly update to the latest
+> version by running `drenv upgrade`.
 
 ## Usage
 
@@ -60,7 +61,8 @@ This allows you to call `drenv` from anywhere in your terminal.
 This command will copy a local DragonRuby installation at the specified path
 into **drenv**'s home directory.
 
-The path should point to the directory that contains the `dragonruby` executable.
+The path should point to the directory that contains the `dragonruby`
+executable.
 
 > [!IMPORTANT]
 > You will need to register at least one DragonRuby installation before you can
@@ -104,5 +106,18 @@ This command will list out all registered versions of DragonRuby.
   6.4
 * 6.3
 ```
+
+### `drenv install <version>`
+
+This command will download and install the specified version of DragonRuby.
+
+This will prompt you to enter your https://dragonruby.org credentials.
+
+> [!IMPORTANT]
+> This command only supports installing Indie and Pro versions of DragonRuby.
+
+### `drenv login` - Requires support from https://dragonruby.org
+
+This command will prompt you to enter your DragonRuby credentials and store a token for future use.
 
 Tested on MacOS Macbook Pro M1 with DragonRuby 5.32, 6.3, and 6.4.


### PR DESCRIPTION
Streamline DR installation by allowing users to download Indie and Pro licenses from their command line.

## New commands

- `drenv login`

  This requires authentication tokens to be implemented on https://dragonruby.org. We should never store a user's password in plaintext, even on their own device.

- `drenv install <version>`

  This command will prompt a user to enter their credentials (as we currently don't have any authentication tokens to cache) and download a version of DragonRuby and register it to `~/.drenv/versions`.

  e.g.

  ```sh
  $ drenv install 6.3-indie
  ```

  ```sh
  $ drenv install 6.3-pro
  ```

## Considerations

- Right now, the DR download API only supports downloading the latest version. We'd probably need to talk to Amir why that is and if we can request specific versions.
- I've looked into Itch.io's API docs and it doesn't look like there is a way to download files via API anymore, unless you're the project owner. This limitation means that I'm unable to add support for downloading the Standard tier versions. Another thing that Amir could possibly support by providing Standard downloads from https://dragonruby.org itself.