### PR TITLE
Add 'add' command along with the 'foodchain' recipe

### DIFF
--- a/commands/add.ts
+++ b/commands/add.ts
@@ -1,0 +1,23 @@
+import { ensureDir } from "@std/fs"
+
+export default async function add(recipe: string) {
+  switch (recipe) {
+    case "foodchain":
+      return foodchain();
+    default:
+      throw new Error(`Unknown recipe: ${recipe}`);
+  }
+}
+
+const foodchain = async () => {
+  console.log("Installing foodchain...")
+
+  const foodchainUrl = "https://raw.githubusercontent.com/pvande/foodchain/refs/heads/main/foodchain.rb"
+
+  const response = await fetch(foodchainUrl)
+  const foodchainText = await response.text()
+
+  await ensureDir("mygame/vendor/pvande/foodchain")
+  await Deno.writeTextFile("mygame/vendor/pvande/foodchain/foodchain.rb", foodchainText)
+  await Deno.writeTextFile("mygame/dependencies.rb", "require \"vendor/pvande/foodchain/foodchain.rb\"\n")
+}

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,4 @@
-export const version = "0.3.4";
+export const version = "0.4.0";
 export const homePath = `${Deno.env.get("HOME")}/.drenv`;
 export const versionsPath = `${homePath}/versions`;
 export const binPath = `${homePath}/bin`;

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
 import { Command } from "npm:commander";
 
+import add from "./commands/add.ts";
 import global from "./commands/global.ts";
 import local from "./commands/local.ts";
 import newCommand from "./commands/new.ts";
@@ -46,6 +47,11 @@ program.command("register")
     "Register a DragonRuby installation. This moves the installation to the $HOME/.drenv directory.",
   )
   .action(actionRunner(register));
+
+program.command("add")
+  .argument("<recipe>", "Name of the recipe to add")
+  .description("Setup a pre-configured library")
+  .action(actionRunner(add));
 
 program.command("global")
   .argument("[version]", "Version of DragonRuby to use")


### PR DESCRIPTION
The new `drenv add <recipe>` command configures curated DragonRuby dependencies.

The first _recipe_ is [pvande/foodchain](https://github.com/pvande/foodchain). `foodchain` is a package/dependency manager for DragonRuby that allows users to keep track of dependencies and be aware of new updates to libraries. It achieves the same goals as [RFC - Package Management #6](https://github.com/Nitemaeric/drenv/pull/6).

> - Fully Decentralized
>   - Pull what you want from wherever it lives.
> - Git-Aware
>   - Pin your dependencies to a particular branch, tag, or commit.
> - Documentation
>   - Borrow code with the confidence that you'll remember it came from.
> - No External Dependencies
>   - Everything runs inside the DragonRuby runtime you already have.
> 
> \- pvande/foodchain's README

This command allows users to bootstrap installation.

## New commands

- `drenv add <recipe>`

  Install/setup a pre-configured library or DragonRuby snippet.

  e.g.

  ```sh
  drenv add foodchain
  ```