### PR TITLE
Install dragonruby from itch io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 builds
 tmp
+
+database.db

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # drenv - DragonRuby Environment Manager
 
 > [!WARNING]
-> Windows is currently not supported. See [#8](https://github.com/Nitemaeric/drenv/issues/8) for more information.
+> Windows is currently not supported. See
+> [#8](https://github.com/Nitemaeric/drenv/issues/8) for more information.
 
 **drenv** is a cross-platform CLI tool that helps you declutter your DragonRuby
 installations.
@@ -17,11 +18,12 @@ releases page.
 Alternatively, you can clone this repo and build the binary yourself.
 
 ```sh
-deno compile --allow-read --allow-write --allow-env --output=builds/drenv --target=aarch64-apple-darwin main.ts
+deno compile --allow-read --allow-write --allow-env --unstable-kv --output=builds/drenv --target=aarch64-apple-darwin main.ts
 ```
 
 > [!NOTE]
-> Once **drenv** has been installed, you can seamlessly update to the latest version by running `drenv upgrade`.
+> Once **drenv** has been installed, you can seamlessly update to the latest
+> version by running `drenv upgrade`.
 
 ## Usage
 
@@ -63,7 +65,8 @@ This allows you to call `drenv` from anywhere in your terminal.
 This command will copy a local DragonRuby installation at the specified path
 into **drenv**'s home directory.
 
-The path should point to the directory that contains the `dragonruby` executable.
+The path should point to the directory that contains the `dragonruby`
+executable.
 
 > [!IMPORTANT]
 > You will need to register at least one DragonRuby installation before you can

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ installations.
 
 ## Installation
 
-For now, you can install **drenv** by downloading the binary from this repo's
-releases page.
+For now, you can install **drenv** by downloading the executable from this
+repo's releases page.
 
-Alternatively, you can clone this repo and build the binary yourself.
+Alternatively, you can clone this repo and build the executable yourself.
 
 ```sh
 deno compile --allow-read --allow-write --allow-env --unstable-kv --output=builds/drenv --target=aarch64-apple-darwin main.ts
@@ -25,7 +25,7 @@ deno compile --allow-read --allow-write --allow-env --unstable-kv --output=build
 > Once **drenv** has been installed, you can seamlessly update to the latest
 > version by running `drenv upgrade`.
 
-## Usage
+## Help
 
 ### `drenv help [command]`
 
@@ -46,12 +46,16 @@ Commands:
   setup             Setup your shell profile to use drenv
   new <name>        Create a new DragonRuby project
   register <path>   Register a DragonRuby installation
+  add <recipe>      Setup a pre-configured library
   global [version]  Get or set the global version of DragonRuby
   local [version]   Get or set the local version of DragonRuby
   versions          List out all locally installed versions of DragonRuby
   upgrade           Upgrade the version of drenv
+  install [tier]    Install the latest version of drenv
   help [command]    display help for command
 ```
+
+## Managng **drenv**
 
 ### `drenv setup`
 
@@ -59,6 +63,13 @@ This command will move the executable to your home directory and show
 instructions on how to add it to your `$PATH`.
 
 This allows you to call `drenv` from anywhere in your terminal.
+
+### `drenv upgrade`
+
+This command will download and upgrade your **drenv** installation to the latest
+version.
+
+## Managing DragonRuby Versions
 
 ### `drenv register <path>`
 
@@ -70,7 +81,7 @@ executable.
 
 > [!IMPORTANT]
 > You will need to register at least one DragonRuby installation before you can
-> use **drenv**.
+> use **drenv** to manage DragonRuby projects.
 
 ### `drenv global [version]`
 
@@ -79,6 +90,18 @@ creating new projects.
 
 If you call `drenv global` without any arguments, it will display the current
 global version.
+
+### `drenv versions`
+
+This command will list out all registered versions of DragonRuby.
+
+```
+  6.4
+* 6.3
+  5.32
+```
+
+## Managing DragonRuby Projects
 
 ### `drenv new <name>`
 
@@ -96,19 +119,16 @@ Under the hood, all **drenv** does is copy the contents of the global DragonRuby
 installation into the current project directory, excluding the `mygame`
 directory.
 
-### `drenv upgrade`
+### `drenv add <recipe>`
 
-This command will download and upgrade your **drenv** installation to the latest
-version.
+This command will run a pre-configured script that sets up a library or tool for
+your DragonRuby project.
 
-### `drenv versions`
+Available recipes:
 
-This command will list out all registered versions of DragonRuby.
+- [foodchain](https://github.com/pvande/foodchain) - Foodchain is a single-file
+  library to help you document and install your DragonRuby game's dependencies.
 
-```
-  5.32
-  6.4
-* 6.3
-```
+---
 
-Tested on MacOS Macbook Pro M1 with DragonRuby 5.32, 6.3, and 6.4.
+Tested on a MacOS Macbook Pro M1 with DragonRuby standard 5.32, 6.3, 6.4, and 6.18.

--- a/commands/add.ts
+++ b/commands/add.ts
@@ -1,23 +1,30 @@
-import { ensureDir } from "@std/fs"
+import { ensureDir } from "@std/fs";
 
 export default async function add(recipe: string) {
   switch (recipe) {
     case "foodchain":
-      return foodchain();
+      return await foodchain();
     default:
       throw new Error(`Unknown recipe: ${recipe}`);
   }
 }
 
 const foodchain = async () => {
-  console.log("Installing foodchain...")
+  console.log("Installing foodchain...");
 
-  const foodchainUrl = "https://raw.githubusercontent.com/pvande/foodchain/refs/heads/main/foodchain.rb"
+  const foodchainUrl =
+    "https://raw.githubusercontent.com/pvande/foodchain/refs/heads/main/foodchain.rb";
 
-  const response = await fetch(foodchainUrl)
-  const foodchainText = await response.text()
+  const response = await fetch(foodchainUrl);
+  const foodchainText = await response.text();
 
-  await ensureDir("mygame/vendor/pvande/foodchain")
-  await Deno.writeTextFile("mygame/vendor/pvande/foodchain/foodchain.rb", foodchainText)
-  await Deno.writeTextFile("mygame/dependencies.rb", "require \"vendor/pvande/foodchain/foodchain.rb\"\n")
-}
+  await ensureDir("mygame/vendor/pvande/foodchain");
+  await Deno.writeTextFile(
+    "mygame/vendor/pvande/foodchain/foodchain.rb",
+    foodchainText,
+  );
+  await Deno.writeTextFile(
+    "mygame/dependencies.rb",
+    'require "vendor/pvande/foodchain/foodchain.rb"\n',
+  );
+};

--- a/commands/global.test.ts
+++ b/commands/global.test.ts
@@ -1,8 +1,8 @@
-import { beforeAll, describe, it } from "jsr:@std/testing/bdd";
-import { assertEquals, assertRejects } from "jsr:@std/assert";
-import { ensureDir } from "jsr:@std/fs";
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import { assertEquals, assertRejects } from "@std/assert";
+import { ensureDir } from "@std/fs";
 
-import global, { NoGlobalVersion, NotInstalled } from "./global.ts";
+import global, { NoGlobalVersion } from "./global.ts";
 
 describe("global", () => {
   describe("when an argument is passed", () => {
@@ -48,7 +48,7 @@ describe("global", () => {
         await Deno.remove(`${Deno.env.get("HOME")}/.drenv/.dragonruby-version`);
       });
 
-      it("raises an error", async () => {
+      it("raises an error", () => {
         assertRejects(
           async () => {
             await global();

--- a/commands/global.ts
+++ b/commands/global.ts
@@ -1,4 +1,4 @@
-import { exists } from "jsr:@std/fs";
+import { exists } from "@std/fs";
 
 import { homePath, versionsPath } from "../constants.ts";
 
@@ -20,7 +20,7 @@ export class NoGlobalVersion extends Error {
   }
 }
 
-export default async function global(version: string | undefined = undefined) {
+export default function global(version: string | undefined = undefined) {
   if (version) {
     return setGlobalVersion(version);
   } else {

--- a/commands/install.ts
+++ b/commands/install.ts
@@ -1,0 +1,120 @@
+import { ElementHandle, launch } from "@astral/astral";
+import { promptSecret } from "@std/cli";
+import { existsSync } from "@std/fs";
+import ora from "ora";
+
+import register from "./register.ts";
+
+const buildTargetLookup: Record<string, string> = {
+  "x86_64-pc-windows-msvc": "dragonruby-gtk-windows-amd64.zip",
+  "x86_64-apple-darwin": "dragonruby-gtk-macos.zip",
+  "aarch64-apple-darwin": "dragonruby-gtk-macos.zip",
+  "x86_64-unknown-linux-gnu": "dragonruby-gtk-linux-amd64.zip",
+  "aarch64-unknown-linux-gnu": "dragonruby-gtk-linux-arm64.zip",
+};
+
+const downloadName = buildTargetLookup[Deno.build.target];
+
+export default async function install(tier: string = "standard") {
+  if (tier !== "standard") {
+    throw new Error("drenv: Only the standard tier is supported at this time");
+  }
+
+  const kv = await Deno.openKv("database.db");
+
+  let username: string = (await kv.get(["itch", "username"])).value as string;
+  let password: string = (await kv.get(["itch", "password"])).value as string;
+
+  const spinner = ora({ discardStdin: false }).start("Signing into itch.io");
+
+  const browser = await launch();
+
+  const page = await browser.newPage("https://itch.io/login");
+
+  const celestial = page.unsafelyGetCelestialBindings();
+
+  await celestial.Browser.setDownloadBehavior({
+    behavior: "allow",
+    downloadPath: "./tmp",
+  });
+
+  const usernameInput = await page.$("input[name='username']");
+
+  if (usernameInput) {
+    if (!username) {
+      username = prompt("Enter your username:") || "";
+    }
+
+    await usernameInput.type(username);
+
+    if (!password) {
+      password = promptSecret("Enter your password:") || "";
+    }
+
+    const passwordInput = await page.$("input[name='password']");
+    await passwordInput!.type(password);
+
+    const submit = await page.$(".login_form_widget form button");
+    await submit!.click();
+
+    await page.waitForNavigation();
+  }
+
+  await kv.set(["itch", "username"], username);
+  await kv.set(["itch", "password"], password);
+
+  spinner.text = "Downloading the latest version of DragonRuby GTK";
+
+  try {
+    await page.goto("https://dragonruby.itch.io/dragonruby-gtk");
+
+    const downloadButton = await page.$(
+      ".purchase_banner.above_game_banner a.button",
+    );
+    await downloadButton!.click();
+
+    await page.waitForNavigation();
+
+    const platformDownloadButtons: Record<string, ElementHandle> = await Array
+      .from<ElementHandle>(await page.$$(".upload")).reduce(
+        async (object, row) => ({
+          ...(await object),
+          [await (await row.$(".name"))!.innerText()]: await row.$(
+            "a.button.download_btn",
+          ),
+        }),
+        Promise.resolve({}),
+      );
+
+    await platformDownloadButtons[downloadName]!.click();
+
+    await new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        clearTimeout(timeoutId);
+        reject(new Error("Download timed out"));
+      }, 10000);
+
+      const intervalId = setInterval(() => {
+        if (existsSync(`./tmp/${downloadName}`)) {
+          clearTimeout(timeoutId);
+          clearInterval(intervalId);
+          resolve(true);
+        }
+      }, 200);
+    });
+
+    spinner.text = "Installing the latest version of DragonRuby GTK";
+
+    const message = await register(`./tmp/${downloadName}`);
+
+    spinner.succeed(message);
+  } catch (err) {
+    const error = err as Error;
+
+    spinner.fail(error.message);
+  } finally {
+    spinner.stop();
+
+    await browser.close();
+  }
+}

--- a/commands/local.ts
+++ b/commands/local.ts
@@ -1,4 +1,4 @@
-import { copy, exists } from "jsr:@std/fs";
+import { copy, exists } from "@std/fs";
 
 import { readVersion } from "../utils/read-version.ts";
 import { versionsPath } from "../constants.ts";
@@ -14,7 +14,7 @@ export class NotInstalled extends Error {
   }
 }
 
-export default async function local(version: string | undefined = undefined) {
+export default function local(version: string | undefined = undefined) {
   if (version) {
     return setLocalVersion(version);
   } else {
@@ -29,7 +29,7 @@ const setLocalVersion = async (version: string) => {
     throw new NotInstalled(version);
   }
 
-  const items = await Deno.readDir(sourceDirectory);
+  const items = Deno.readDir(sourceDirectory);
 
   for await (const item of items) {
     if (item.name == "mygame") {
@@ -42,6 +42,6 @@ const setLocalVersion = async (version: string) => {
   }
 };
 
-const getLocalVersion = async () => {
+const getLocalVersion = () => {
   return readVersion("./CHANGELOG-CURR.txt");
 };

--- a/commands/new.ts
+++ b/commands/new.ts
@@ -1,4 +1,4 @@
-import { copy } from "jsr:@std/fs";
+import { copy } from "@std/fs";
 
 import { versionsPath } from "../constants.ts";
 

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -1,4 +1,4 @@
-import { ensureDir, exists, move } from "jsr:@std/fs";
+import { ensureDir, exists, move } from "@std/fs";
 
 import { binPath, shell } from "../constants.ts";
 

--- a/commands/upgrade.ts
+++ b/commands/upgrade.ts
@@ -1,4 +1,4 @@
-import { greaterThan, parse } from "jsr:@std/semver";
+import { greaterThan, parse } from "@std/semver";
 
 import config from "../deno.json" with { type: "json" };
 import { drenvBinPath } from "../constants.ts";
@@ -9,7 +9,7 @@ type Asset = {
   node_id: string;
   name: string;
   label: string | null;
-  uploader: any;
+  uploader: unknown;
   content_type: string;
   state: string;
   size: number;

--- a/commands/upgrade.ts
+++ b/commands/upgrade.ts
@@ -1,7 +1,7 @@
 import { greaterThan, parse } from "jsr:@std/semver";
 
-import { program } from "../main.ts";
-import { drenvBinPath, version } from "../constants.ts";
+import config from "../deno.json" with { type: "json" };
+import { drenvBinPath } from "../constants.ts";
 
 type Asset = {
   url: string;
@@ -20,7 +20,7 @@ type Asset = {
 };
 
 export default async function upgrade() {
-  console.log(`Current version is v${program.version()}`);
+  console.log(`Current version is ${config.version}`);
   console.log("Checking for updates...");
 
   const dataResponse = await fetch(
@@ -28,7 +28,7 @@ export default async function upgrade() {
   );
   const data = await dataResponse.json();
 
-  const localVersion = parse(version);
+  const localVersion = parse(config.version);
   const remoteVersion = parse(data.tag_name.slice(1));
 
   if (greaterThan(remoteVersion, localVersion)) {

--- a/commands/versions.ts
+++ b/commands/versions.ts
@@ -2,7 +2,19 @@ import { readVersion } from "../utils/read-version.ts";
 import { versionsPath } from "../constants.ts";
 
 export default async function versions() {
-  const directories = await Deno.readDir(versionsPath);
+  const directories = (await Array.fromAsync(Deno.readDir(versionsPath)))
+    .toSorted(
+      (first, second) => {
+        const [secondMajor, secondMinor] = second.name.split(".").map(Number);
+        const [firstMajor, firstMinor] = first.name.split(".").map(Number);
+
+        if (firstMajor == secondMajor) {
+          return secondMinor - firstMinor;
+        }
+
+        return (secondMajor - firstMajor);
+      },
+    );
 
   const currentVersion = await readVersion("./CHANGELOG-CURR.txt");
 

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,3 @@
-export const version = "0.4.0";
 export const homePath = `${Deno.env.get("HOME")}/.drenv`;
 export const versionsPath = `${homePath}/versions`;
 export const binPath = `${homePath}/bin`;

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.5.0",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "compile": "deno compile -A --output=builds/ main.ts",

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "version": "0.5.0",
   "tasks": {
     "dev": "deno run --watch main.ts",
-    "compile": "deno compile -A --output=builds/ main.ts",
+    "compile": "deno compile -A --unstable-kv --output=builds/ main.ts",
     "compile:windows-x86": "deno compile -A --output=builds/x86_64-pc-windows-msvc.drenv --target=x86_64-pc-windows-msvc main.ts",
     "compile:macos-x86": "deno compile -A --output=builds/x86_64-apple-darwin.drenv --target=x86_64-apple-darwin main.ts",
     "compile:macos-arm64": "deno compile -A --output=builds/aarch64-apple-darwin.drenv --target=aarch64-apple-darwin main.ts",
@@ -11,8 +11,15 @@
     "compile:all": "deno task compile:windows-x86 & deno task compile:macos-x86 & deno task compile:macos-arm64 & deno task compile:linux-x86 & deno task compile:linux-arm64"
   },
   "imports": {
+    "@astral/astral": "jsr:@astral/astral@^0.5.2",
     "@std/assert": "jsr:@std/assert@1",
-    "@std/fs": "jsr:@std/fs@^1.0.4",
-    "commander": "npm:commander@^12.1.0"
+    "@std/cli": "jsr:@std/cli@^1.0.12",
+    "@std/fs": "jsr:@std/fs@^1.0.11",
+    "@std/path": "jsr:@std/path@^1.0.8",
+    "@std/semver": "jsr:@std/semver@^1.0.3",
+    "@std/testing": "jsr:@std/testing@^1.0.9",
+    "@zip-js/zip-js": "jsr:@zip-js/zip-js@^2.7.57",
+    "commander": "npm:commander@^13.1.0",
+    "ora": "npm:ora@^8.1.1"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,36 +1,119 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@astral/astral@*": "0.5.2",
+    "jsr:@astral/astral@~0.5.2": "0.5.2",
+    "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@std/assert@*": "1.0.6",
-    "jsr:@std/assert@1": "1.0.6",
+    "jsr:@std/assert@1": "1.0.11",
+    "jsr:@std/assert@^1.0.10": "1.0.11",
     "jsr:@std/assert@^1.0.6": "1.0.6",
-    "jsr:@std/fs@*": "1.0.4",
-    "jsr:@std/fs@^1.0.4": "1.0.4",
+    "jsr:@std/async@1": "1.0.10",
+    "jsr:@std/cli@*": "1.0.6",
+    "jsr:@std/cli@^1.0.12": "1.0.12",
+    "jsr:@std/data-structures@^1.0.6": "1.0.6",
+    "jsr:@std/fmt@1.0.3": "1.0.3",
+    "jsr:@std/fs@*": "1.0.10",
+    "jsr:@std/fs@1": "1.0.11",
+    "jsr:@std/fs@^1.0.11": "1.0.11",
+    "jsr:@std/fs@^1.0.4": "1.0.10",
+    "jsr:@std/fs@^1.0.9": "1.0.11",
     "jsr:@std/internal@^1.0.4": "1.0.4",
+    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/io@0.225.0": "0.225.0",
+    "jsr:@std/path@*": "1.0.8",
+    "jsr:@std/path@1": "1.0.8",
     "jsr:@std/path@^1.0.6": "1.0.6",
+    "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/semver@*": "1.0.3",
+    "jsr:@std/semver@^1.0.3": "1.0.3",
     "jsr:@std/testing@*": "1.0.3",
-    "npm:commander@*": "12.1.0",
-    "npm:commander@^12.1.0": "12.1.0"
+    "jsr:@std/testing@^1.0.9": "1.0.9",
+    "jsr:@zip-js/zip-js@*": "2.7.54",
+    "jsr:@zip-js/zip-js@^2.7.52": "2.7.57",
+    "jsr:@zip-js/zip-js@^2.7.54": "2.7.54",
+    "jsr:@zip-js/zip-js@^2.7.57": "2.7.57",
+    "npm:commander@^13.1.0": "13.1.0",
+    "npm:ora@*": "8.1.1",
+    "npm:ora@^8.1.1": "8.1.1"
   },
   "jsr": {
+    "@astral/astral@0.5.2": {
+      "integrity": "dc4b7e0ea5d8186fcd9e33e2c54e62913d7eb99d5a2d4f987b1c5399d8e295de",
+      "dependencies": [
+        "jsr:@deno-library/progress",
+        "jsr:@std/async",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1",
+        "jsr:@zip-js/zip-js@^2.7.52"
+      ]
+    },
+    "@deno-library/progress@1.5.1": {
+      "integrity": "966611826b8bb27baae73ab1c4fa4317cd4edd2abb99750cd6f8488d22d5b121",
+      "dependencies": [
+        "jsr:@std/fmt",
+        "jsr:@std/io"
+      ]
+    },
     "@std/assert@1.0.6": {
       "integrity": "1904c05806a25d94fe791d6d883b685c9e2dcd60e4f9fc30f4fc5cf010c72207",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.4"
       ]
+    },
+    "@std/assert@1.0.11": {
+      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.5"
+      ]
+    },
+    "@std/async@1.0.10": {
+      "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
+    },
+    "@std/cli@1.0.6": {
+      "integrity": "d22d8b38c66c666d7ad1f2a66c5b122da1704f985d3c47f01129f05abb6c5d3d"
+    },
+    "@std/cli@1.0.12": {
+      "integrity": "e5cfb7814d189da174ecd7a34fbbd63f3513e24a1b307feb2fcd5da47a070d90"
+    },
+    "@std/data-structures@1.0.6": {
+      "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
+    },
+    "@std/fmt@1.0.3": {
+      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
     },
     "@std/fs@1.0.4": {
       "integrity": "2907d32d8d1d9e540588fd5fe0ec21ee638134bd51df327ad4e443aaef07123c",
       "dependencies": [
-        "jsr:@std/path"
+        "jsr:@std/path@^1.0.6"
+      ]
+    },
+    "@std/fs@1.0.10": {
+      "integrity": "bf041f9d7a0a460817f0421be8946d0e06011b3433e6c83a215628de5e3c7c2c",
+      "dependencies": [
+        "jsr:@std/path@^1.0.8"
+      ]
+    },
+    "@std/fs@1.0.11": {
+      "integrity": "ba674672693340c5ebdd018b4fe1af46cb08741f42b4c538154e97d217b55bdd",
+      "dependencies": [
+        "jsr:@std/path@^1.0.8"
       ]
     },
     "@std/internal@1.0.4": {
       "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
     },
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/io@0.225.0": {
+      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
+    },
     "@std/path@1.0.6": {
       "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
     "@std/semver@1.0.3": {
       "integrity": "7c139c6076a080eeaa4252c78b95ca5302818d7eafab0470d34cafd9930c13c8"
@@ -39,13 +122,116 @@
       "integrity": "f98c2bee53860a5916727d7e7d3abe920dd6f9edace022e2d059f00d05c2cf42",
       "dependencies": [
         "jsr:@std/assert@^1.0.6",
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.4"
       ]
+    },
+    "@std/testing@1.0.9": {
+      "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.10",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.9",
+        "jsr:@std/internal@^1.0.5",
+        "jsr:@std/path@^1.0.8"
+      ]
+    },
+    "@zip-js/zip-js@2.7.54": {
+      "integrity": "a28b93b56a6cb2ed0f613355b2e9120ea9f6e9703dd6ae1bbc0088cfa3fef692"
+    },
+    "@zip-js/zip-js@2.7.57": {
+      "integrity": "15465ff627e321775870ad493bc043ca2d97940bda58d709c49908d39f4b0524"
     }
   },
   "npm": {
-    "commander@12.1.0": {
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
+    "ansi-regex@6.1.0": {
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
+    },
+    "chalk@5.4.1": {
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="
+    },
+    "cli-cursor@5.0.0": {
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dependencies": [
+        "restore-cursor"
+      ]
+    },
+    "cli-spinners@2.9.2": {
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="
+    },
+    "commander@13.1.0": {
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="
+    },
+    "emoji-regex@10.4.0": {
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
+    },
+    "get-east-asian-width@1.3.0": {
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="
+    },
+    "is-interactive@2.0.0": {
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
+    },
+    "is-unicode-supported@1.3.0": {
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+    },
+    "is-unicode-supported@2.1.0": {
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
+    },
+    "log-symbols@6.0.0": {
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dependencies": [
+        "chalk",
+        "is-unicode-supported@1.3.0"
+      ]
+    },
+    "mimic-function@5.0.1": {
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="
+    },
+    "onetime@7.0.0": {
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dependencies": [
+        "mimic-function"
+      ]
+    },
+    "ora@8.1.1": {
+      "integrity": "sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw==",
+      "dependencies": [
+        "chalk",
+        "cli-cursor",
+        "cli-spinners",
+        "is-interactive",
+        "is-unicode-supported@2.1.0",
+        "log-symbols",
+        "stdin-discarder",
+        "string-width",
+        "strip-ansi"
+      ]
+    },
+    "restore-cursor@5.1.0": {
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dependencies": [
+        "onetime",
+        "signal-exit"
+      ]
+    },
+    "signal-exit@4.1.0": {
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+    },
+    "stdin-discarder@0.2.2": {
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="
+    },
+    "string-width@7.2.0": {
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dependencies": [
+        "emoji-regex",
+        "get-east-asian-width",
+        "strip-ansi"
+      ]
+    },
+    "strip-ansi@7.1.0": {
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": [
+        "ansi-regex"
+      ]
     }
   },
   "remote": {
@@ -55,9 +241,16 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@astral/astral@~0.5.2",
       "jsr:@std/assert@1",
-      "jsr:@std/fs@^1.0.4",
-      "npm:commander@^12.1.0"
+      "jsr:@std/cli@^1.0.12",
+      "jsr:@std/fs@^1.0.11",
+      "jsr:@std/path@^1.0.8",
+      "jsr:@std/semver@^1.0.3",
+      "jsr:@std/testing@^1.0.9",
+      "jsr:@zip-js/zip-js@^2.7.57",
+      "npm:commander@^13.1.0",
+      "npm:ora@^8.1.1"
     ]
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { Command } from "npm:commander";
+import config from "./deno.json" with { type: "json" };
 
 import add from "./commands/add.ts";
 import global from "./commands/global.ts";
@@ -8,8 +9,6 @@ import register from "./commands/register.ts";
 import setup from "./commands/setup.ts";
 import upgrade from "./commands/upgrade.ts";
 import versions from "./commands/versions.ts";
-
-import { version } from "./constants.ts";
 
 export const program = new Command();
 
@@ -29,7 +28,7 @@ const actionRunner = (fn: (...args: any[]) => Promise<any>) => {
 program
   .name("drenv")
   .description("CLI to manage DragonRuby environments")
-  .version(version);
+  .version(config.version);
 
 program.command("setup")
   .description("Setup your shell profile to use drenv")

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,10 @@
-import { Command } from "npm:commander";
+import { Argument, Command } from "commander";
+
 import config from "./deno.json" with { type: "json" };
 
 import add from "./commands/add.ts";
 import global from "./commands/global.ts";
+import install from "./commands/install.ts";
 import local from "./commands/local.ts";
 import newCommand from "./commands/new.ts";
 import register from "./commands/register.ts";
@@ -12,17 +14,16 @@ import versions from "./commands/versions.ts";
 
 export const program = new Command();
 
-const actionRunner = (fn: (...args: any[]) => Promise<any>) => {
-  return (...args: any[]): any =>
+const actionRunner = (fn: (...args: string[]) => Promise<unknown>) => {
+  return (...args: string[]): void | Promise<void> =>
     fn(...args)
       .then(
-        (value) =>
-          (typeof value === "string" ||
-            typeof value === "number") && console.log(value),
+        (value) => {
+          (typeof value === "string" || typeof value === "number") &&
+            console.log(value);
+        },
       )
-      .catch(
-        (error) => console.error(error.message),
-      );
+      .catch((error) => console.error(error.message));
 };
 
 program
@@ -30,16 +31,19 @@ program
   .description("CLI to manage DragonRuby environments")
   .version(config.version);
 
-program.command("setup")
+program
+  .command("setup")
   .description("Setup your shell profile to use drenv")
   .action(actionRunner(setup));
 
-program.command("new")
+program
+  .command("new")
   .argument("<name>", "Name of the new project")
   .description("Create a new DragonRuby project")
   .action(actionRunner(newCommand));
 
-program.command("register")
+program
+  .command("register")
   .argument("<path>", "Path to a fresh DragonRuby directory")
   .summary("Register a DragonRuby installation")
   .description(
@@ -47,27 +51,42 @@ program.command("register")
   )
   .action(actionRunner(register));
 
-program.command("add")
+program
+  .command("add")
   .argument("<recipe>", "Name of the recipe to add")
   .description("Setup a pre-configured library")
   .action(actionRunner(add));
 
-program.command("global")
+program
+  .command("global")
   .argument("[version]", "Version of DragonRuby to use")
   .description("Get or set the global version of DragonRuby")
   .action(actionRunner(global));
 
-program.command("local")
+program
+  .command("local")
   .argument("[version]", "Version of DragonRuby to use")
   .description("Get or set the local version of DragonRuby")
   .action(actionRunner(local));
 
-program.command("versions")
+program
+  .command("versions")
   .description("List out all locally installed versions of DragonRuby")
   .action(actionRunner(versions));
 
-program.command("upgrade")
+program
+  .command("upgrade")
   .description("Upgrade the version of drenv")
   .action(actionRunner(upgrade));
+
+program
+  .command("install")
+  .addArgument(
+    new Argument("[tier]", "Tier of DragonRuby to install")
+      .choices(["standard", "indie", "pro"])
+      .default("standard"),
+  )
+  .description("Install the latest version of drenv")
+  .action(actionRunner(install));
 
 program.parse();

--- a/utils/read-version.ts
+++ b/utils/read-version.ts
@@ -9,7 +9,9 @@ export const readVersion = async (
     const content = await readFirstLine(path);
 
     currentVersion = content.match(/[0-9\.]+/)?.[0];
-  } catch (error) {}
+  } catch (_error) {
+    // Do nothing
+  }
 
   return currentVersion;
 };

--- a/utils/version.ts
+++ b/utils/version.ts
@@ -1,0 +1,20 @@
+import { exists } from "@std/fs";
+
+/**
+ * @param directoryPath - The path to the DragonRuby installation directory.
+ */
+export const versionCommand = async (directoryPath: string) => {
+  if (!await exists(directoryPath + "/dragonruby")) {
+    throw new Error(
+      "drenv: <path> is missing dragonruby executable",
+    );
+  }
+
+  const command = new Deno.Command(directoryPath + "/dragonruby", {
+    args: ["--version"],
+  });
+
+  const { stdout } = await command.output();
+
+  return new TextDecoder().decode(stdout).trim();
+};


### PR DESCRIPTION
## Changes

- Add unzip support for `register`.
  - This allows users to run `drenv register 
- Add `install [tier]` command.
  -  Currently only supports the `standard` edition from https://dragonruby.itch.io/dragonruby-gtk.