### PR TITLE
Replace browser automation with itch.io API for install

### DIFF
--- a/commands/install.ts
+++ b/commands/install.ts
@@ -1,10 +1,12 @@
-import { ElementHandle, launch } from "@astral/astral";
 import { promptSecret } from "@std/cli";
-import { existsSync } from "@std/fs";
-import ora from "ora";
+import { ensureDir } from "@std/fs";
+import ora, { type Ora } from "ora";
 
 import register from "./register.ts";
 import { homePath } from "../constants.ts";
+
+const DRAGONRUBY_GAME_ID = 404609;
+const ITCH_API = "https://api.itch.io";
 
 const buildTargetLookup: Record<string, string> = {
   "x86_64-pc-windows-msvc": "dragonruby-gtk-windows-amd64.zip",
@@ -16,106 +18,185 @@ const buildTargetLookup: Record<string, string> = {
 
 const downloadName = buildTargetLookup[Deno.build.target];
 
+async function itchLogin(username: string, password: string): Promise<string> {
+  const res = await fetch(`${ITCH_API}/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ username, password, source: "desktop" }),
+  });
+
+  const data = await res.json();
+
+  if (data.errors) {
+    throw new Error(`drenv: itch.io login failed: ${data.errors.join(", ")}`);
+  }
+
+  if (data.recaptchaNeeded) {
+    throw new Error(
+      "drenv: itch.io is requesting a CAPTCHA — try logging in via the itch app first",
+    );
+  }
+
+  if (data.totpNeeded) {
+    const code = prompt("Enter your 2FA code:") ?? "";
+
+    const totpRes = await fetch(`${ITCH_API}/totp/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ token: data.token, code }),
+    });
+
+    const totpData = await totpRes.json();
+
+    if (totpData.errors) {
+      throw new Error(
+        `drenv: 2FA verification failed: ${totpData.errors.join(", ")}`,
+      );
+    }
+
+    return totpData.key.key;
+  }
+
+  return data.key.key;
+}
+
+async function authenticate(kv: Deno.Kv, spinner: Ora): Promise<string> {
+  spinner.stop();
+  const username = prompt("itch.io username or email:") ?? "";
+  const password = promptSecret("itch.io password:") ?? "";
+  spinner.start("Signing into itch.io");
+
+  const apiKey = await itchLogin(username, password);
+  await kv.set(["itch", "apiKey"], apiKey);
+  return apiKey;
+}
+
+async function getDownloadKeyId(apiKey: string): Promise<number> {
+  const res = await fetch(`${ITCH_API}/profile/owned-keys`, {
+    headers: { "Authorization": apiKey },
+  });
+
+  const data = await res.json();
+
+  if (data.errors) {
+    throw new Error(
+      `drenv: could not fetch owned keys: ${data.errors.join(", ")}`,
+    );
+  }
+
+  const entry = data.owned_keys?.find(
+    (k: { game_id: number }) => k.game_id === DRAGONRUBY_GAME_ID,
+  );
+
+  if (!entry) {
+    throw new Error(
+      "drenv: no DragonRuby GTK purchase found on this itch.io account",
+    );
+  }
+
+  return entry.id;
+}
+
+async function getUploadId(
+  apiKey: string,
+  downloadKeyId: number,
+): Promise<number> {
+  const res = await fetch(
+    `${ITCH_API}/games/${DRAGONRUBY_GAME_ID}/uploads?download_key_id=${downloadKeyId}`,
+    { headers: { "Authorization": apiKey } },
+  );
+
+  const data = await res.json();
+
+  if (data.errors) {
+    throw new Error(
+      `drenv: could not list uploads: ${data.errors.join(", ")}`,
+    );
+  }
+
+  const uploads: { id: number; filename: string }[] = Array.isArray(
+    data.uploads,
+  )
+    ? data.uploads
+    : Object.values(data.uploads);
+
+  const upload = uploads.find((u) => u.filename === downloadName);
+
+  if (!upload) {
+    throw new Error(`drenv: no upload found for platform (${downloadName})`);
+  }
+
+  return upload.id;
+}
+
+async function downloadUpload(
+  apiKey: string,
+  uploadId: number,
+  downloadKeyId: number,
+  destPath: string,
+): Promise<void> {
+  const redirectRes = await fetch(
+    `${ITCH_API}/uploads/${uploadId}/download?download_key_id=${downloadKeyId}`,
+    { headers: { "Authorization": apiKey }, redirect: "manual" },
+  );
+
+  const downloadUrl = redirectRes.headers.get("location");
+
+  if (!downloadUrl) {
+    throw new Error("drenv: failed to get download URL from itch.io");
+  }
+
+  const fileRes = await fetch(downloadUrl);
+
+  if (!fileRes.ok || !fileRes.body) {
+    throw new Error(`drenv: download failed with status ${fileRes.status}`);
+  }
+
+  await ensureDir("./tmp");
+  const file = await Deno.create(destPath);
+  await fileRes.body.pipeTo(file.writable);
+}
+
 export default async function install(tier: string = "standard") {
   if (tier !== "standard") {
     throw new Error("drenv: Only the standard tier is supported at this time");
   }
 
   const kv = await Deno.openKv(homePath + "/database.db");
-
-  let username: string = (await kv.get(["itch", "username"])).value as string;
-  let password: string = (await kv.get(["itch", "password"])).value as string;
+  let apiKey: string = (await kv.get(["itch", "apiKey"])).value as string;
 
   const spinner = ora({ discardStdin: false }).start("Signing into itch.io");
 
-  const browser = await launch();
-
-  const page = await browser.newPage("https://itch.io/login");
-
-  const celestial = page.unsafelyGetCelestialBindings();
-
-  await celestial.Browser.setDownloadBehavior({
-    behavior: "allow",
-    downloadPath: "./tmp",
-  });
-
-  const usernameInput = await page.$("input[name='username']");
-
-  if (usernameInput) {
-    if (!username) {
-      username = prompt("Enter your username:") || "";
-    }
-
-    await usernameInput.type(username);
-
-    if (!password) {
-      password = promptSecret("Enter your password:") || "";
-    }
-
-    const passwordInput = await page.$("input[name='password']");
-    await passwordInput!.type(password);
-
-    const submit = await page.$(".login_form_widget form button");
-    await submit!.click();
-
-    await page.waitForNavigation();
-  }
-
-  await kv.set(["itch", "username"], username);
-  await kv.set(["itch", "password"], password);
-
-  spinner.text = "Downloading the latest version of DragonRuby GTK";
-
   try {
-    await page.goto("https://dragonruby.itch.io/dragonruby-gtk");
+    if (!apiKey) {
+      apiKey = await authenticate(kv, spinner);
+    }
 
-    const downloadButton = await page.$(
-      ".purchase_banner.above_game_banner a.button",
-    );
-    await downloadButton!.click();
+    spinner.text = "Finding DragonRuby GTK download key...";
+    let downloadKeyId: number;
+    try {
+      downloadKeyId = await getDownloadKeyId(apiKey);
+    } catch {
+      // Cached key may be expired — re-authenticate and retry once
+      apiKey = await authenticate(kv, spinner);
+      downloadKeyId = await getDownloadKeyId(apiKey);
+    }
 
-    await page.waitForNavigation();
+    spinner.text = `Downloading ${downloadName}...`;
+    const [uploadId] = await Promise.all([
+      getUploadId(apiKey, downloadKeyId),
+      ensureDir("./tmp"),
+    ]);
 
-    const platformDownloadButtons: Record<string, ElementHandle> = await Array
-      .from<ElementHandle>(await page.$$(".upload")).reduce(
-        async (object, row) => ({
-          ...(await object),
-          [await (await row.$(".name"))!.innerText()]: await row.$(
-            "a.button.download_btn",
-          ),
-        }),
-        Promise.resolve({}),
-      );
+    await downloadUpload(apiKey, uploadId, downloadKeyId, `./tmp/${downloadName}`);
 
-    await platformDownloadButtons[downloadName]!.click();
-
-    await new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        clearTimeout(timeoutId);
-        reject(new Error("Download timed out"));
-      }, 10000);
-
-      const intervalId = setInterval(() => {
-        if (existsSync(`./tmp/${downloadName}`)) {
-          clearTimeout(timeoutId);
-          clearInterval(intervalId);
-          resolve(true);
-        }
-      }, 200);
-    });
-
-    spinner.text = "Installing the latest version of DragonRuby GTK";
-
+    spinner.text = "Installing...";
     const message = await register(`./tmp/${downloadName}`);
-
     spinner.succeed(message);
   } catch (err) {
-    const error = err as Error;
-
-    spinner.fail(error.message);
+    spinner.fail((err as Error).message);
   } finally {
     spinner.stop();
-
-    await browser.close();
+    kv.close();
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.2",
+  "version": "0.6.0",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "compile": "deno compile -A --unstable-kv --output=builds/ main.ts",
@@ -11,7 +11,6 @@
     "compile:all": "deno task compile:windows-x86 & deno task compile:macos-x86 & deno task compile:macos-arm64 & deno task compile:linux-x86 & deno task compile:linux-arm64"
   },
   "imports": {
-    "@astral/astral": "jsr:@astral/astral@^0.5.2",
     "@std/assert": "jsr:@std/assert@1",
     "@std/cli": "jsr:@std/cli@^1.0.12",
     "@std/fs": "jsr:@std/fs@^1.0.11",

--- a/deno.lock
+++ b/deno.lock
@@ -1,74 +1,27 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@astral/astral@*": "0.5.2",
-    "jsr:@astral/astral@~0.5.2": "0.5.2",
-    "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@std/assert@*": "1.0.6",
-    "jsr:@std/assert@1": "1.0.11",
-    "jsr:@std/assert@^1.0.10": "1.0.11",
     "jsr:@std/assert@^1.0.6": "1.0.6",
-    "jsr:@std/async@1": "1.0.10",
     "jsr:@std/cli@*": "1.0.6",
     "jsr:@std/cli@^1.0.12": "1.0.12",
-    "jsr:@std/data-structures@^1.0.6": "1.0.6",
-    "jsr:@std/fmt@1.0.3": "1.0.3",
-    "jsr:@std/fs@*": "1.0.10",
-    "jsr:@std/fs@1": "1.0.11",
-    "jsr:@std/fs@^1.0.11": "1.0.11",
-    "jsr:@std/fs@^1.0.4": "1.0.10",
-    "jsr:@std/fs@^1.0.9": "1.0.11",
     "jsr:@std/internal@^1.0.4": "1.0.4",
-    "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/io@0.225.0": "0.225.0",
-    "jsr:@std/path@*": "1.0.8",
-    "jsr:@std/path@1": "1.0.8",
     "jsr:@std/path@^1.0.6": "1.0.6",
-    "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/semver@*": "1.0.3",
     "jsr:@std/semver@^1.0.3": "1.0.3",
     "jsr:@std/testing@*": "1.0.3",
-    "jsr:@std/testing@^1.0.9": "1.0.9",
     "jsr:@zip-js/zip-js@*": "2.7.54",
-    "jsr:@zip-js/zip-js@^2.7.52": "2.7.57",
     "jsr:@zip-js/zip-js@^2.7.54": "2.7.54",
-    "jsr:@zip-js/zip-js@^2.7.57": "2.7.57",
     "npm:commander@^13.1.0": "13.1.0",
     "npm:ora@*": "8.1.1",
     "npm:ora@^8.1.1": "8.1.1"
   },
   "jsr": {
-    "@astral/astral@0.5.2": {
-      "integrity": "dc4b7e0ea5d8186fcd9e33e2c54e62913d7eb99d5a2d4f987b1c5399d8e295de",
-      "dependencies": [
-        "jsr:@deno-library/progress",
-        "jsr:@std/async",
-        "jsr:@std/fs@1",
-        "jsr:@std/path@1",
-        "jsr:@zip-js/zip-js@^2.7.52"
-      ]
-    },
-    "@deno-library/progress@1.5.1": {
-      "integrity": "966611826b8bb27baae73ab1c4fa4317cd4edd2abb99750cd6f8488d22d5b121",
-      "dependencies": [
-        "jsr:@std/fmt",
-        "jsr:@std/io"
-      ]
-    },
     "@std/assert@1.0.6": {
       "integrity": "1904c05806a25d94fe791d6d883b685c9e2dcd60e4f9fc30f4fc5cf010c72207",
       "dependencies": [
-        "jsr:@std/internal@^1.0.4"
+        "jsr:@std/internal"
       ]
-    },
-    "@std/assert@1.0.11": {
-      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.5"
-      ]
-    },
-    "@std/async@1.0.10": {
-      "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
     },
     "@std/cli@1.0.6": {
       "integrity": "d22d8b38c66c666d7ad1f2a66c5b122da1704f985d3c47f01129f05abb6c5d3d"
@@ -76,44 +29,17 @@
     "@std/cli@1.0.12": {
       "integrity": "e5cfb7814d189da174ecd7a34fbbd63f3513e24a1b307feb2fcd5da47a070d90"
     },
-    "@std/data-structures@1.0.6": {
-      "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
-    },
-    "@std/fmt@1.0.3": {
-      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
-    },
     "@std/fs@1.0.4": {
       "integrity": "2907d32d8d1d9e540588fd5fe0ec21ee638134bd51df327ad4e443aaef07123c",
       "dependencies": [
-        "jsr:@std/path@^1.0.6"
-      ]
-    },
-    "@std/fs@1.0.10": {
-      "integrity": "bf041f9d7a0a460817f0421be8946d0e06011b3433e6c83a215628de5e3c7c2c",
-      "dependencies": [
-        "jsr:@std/path@^1.0.8"
-      ]
-    },
-    "@std/fs@1.0.11": {
-      "integrity": "ba674672693340c5ebdd018b4fe1af46cb08741f42b4c538154e97d217b55bdd",
-      "dependencies": [
-        "jsr:@std/path@^1.0.8"
+        "jsr:@std/path"
       ]
     },
     "@std/internal@1.0.4": {
       "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
     },
-    "@std/internal@1.0.5": {
-      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
-    },
-    "@std/io@0.225.0": {
-      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
-    },
     "@std/path@1.0.6": {
       "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
-    },
-    "@std/path@1.0.8": {
-      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
     "@std/semver@1.0.3": {
       "integrity": "7c139c6076a080eeaa4252c78b95ca5302818d7eafab0470d34cafd9930c13c8"
@@ -122,24 +48,11 @@
       "integrity": "f98c2bee53860a5916727d7e7d3abe920dd6f9edace022e2d059f00d05c2cf42",
       "dependencies": [
         "jsr:@std/assert@^1.0.6",
-        "jsr:@std/internal@^1.0.4"
-      ]
-    },
-    "@std/testing@1.0.9": {
-      "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.10",
-        "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.9",
-        "jsr:@std/internal@^1.0.5",
-        "jsr:@std/path@^1.0.8"
+        "jsr:@std/internal"
       ]
     },
     "@zip-js/zip-js@2.7.54": {
       "integrity": "a28b93b56a6cb2ed0f613355b2e9120ea9f6e9703dd6ae1bbc0088cfa3fef692"
-    },
-    "@zip-js/zip-js@2.7.57": {
-      "integrity": "15465ff627e321775870ad493bc043ca2d97940bda58d709c49908d39f4b0524"
     }
   },
   "npm": {
@@ -241,7 +154,6 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@astral/astral@~0.5.2",
       "jsr:@std/assert@1",
       "jsr:@std/cli@^1.0.12",
       "jsr:@std/fs@^1.0.11",


### PR DESCRIPTION
## Summary

- Removes `@astral/astral` (headless Chromium) — eliminates the largest dependency and all browser automation code
- Replaces the fragile CSS-selector-based download flow with direct `fetch` calls to `api.itch.io`
- New flow: login → get owned download key → list uploads → stream download → register
- Handles 2FA (TOTP) and CAPTCHA detection
- Credentials stored as a revocable API key instead of plaintext username/password
- Cached key auto-refreshes on expiry (re-prompts once)

## Test plan

- [x] `drenv install` with no cached credentials prompts for username/password and completes successfully
- [x] Re-running `drenv install` reuses the cached API key without prompting
- [x] Deleting `~/.drenv/database.db` and re-running prompts again
- [ ] Test with a 2FA-enabled account
- [x] Verify the installed version appears in `drenv versions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)