### PR TITLE
Add changelog command and upstream version check

### DIFF
--- a/commands/changelog.test.ts
+++ b/commands/changelog.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { assertEquals, assertRejects } from "@std/assert";
+import { ensureDir } from "@std/fs";
+
+import changelog from "./changelog.ts";
+import { versionsPath } from "../constants.ts";
+
+const FIXTURE = `* 99.99
+** [Bugfix] Fixed a thing in the latest version.
+** [Support] Added a new helper.
+* 99.98
+** [Bugfix] Fixed a thing in the previous version.
+* 99.97
+** [Bugfix] Fixed an even older thing.
+`;
+
+describe("changelog", () => {
+  beforeAll(async () => {
+    await ensureDir(`${versionsPath}/99.99`);
+    await ensureDir(`${versionsPath}/99.98`);
+    await Deno.writeTextFile(
+      `${versionsPath}/99.99/CHANGELOG-CURR.txt`,
+      FIXTURE,
+    );
+    await Deno.writeTextFile(
+      `${versionsPath}/99.98/CHANGELOG-CURR.txt`,
+      FIXTURE,
+    );
+  });
+
+  afterAll(async () => {
+    await Deno.remove(`${versionsPath}/99.99`, { recursive: true });
+    await Deno.remove(`${versionsPath}/99.98`, { recursive: true });
+  });
+
+  describe("when no version is passed", () => {
+    it("returns the entry for the latest installed version", async () => {
+      const result = await changelog();
+
+      assertEquals(
+        result,
+        "* 99.99\n" +
+          "** [Bugfix] Fixed a thing in the latest version.\n" +
+          "** [Support] Added a new helper.",
+      );
+    });
+  });
+
+  describe("when a version is passed", () => {
+    it("returns the entry for that version", async () => {
+      const result = await changelog("99.98");
+
+      assertEquals(
+        result,
+        "* 99.98\n** [Bugfix] Fixed a thing in the previous version.",
+      );
+    });
+
+    it("returns the last entry without a trailing version header", async () => {
+      const result = await changelog("99.97");
+
+      assertEquals(
+        result,
+        "* 99.97\n** [Bugfix] Fixed an even older thing.",
+      );
+    });
+
+    it("rejects when the version is not in the changelog", async () => {
+      await assertRejects(
+        () => changelog("0.0"),
+        Error,
+        "drenv: no changelog entry found for version 0.0",
+      );
+    });
+  });
+});

--- a/commands/changelog.ts
+++ b/commands/changelog.ts
@@ -1,0 +1,76 @@
+import { exists } from "@std/fs";
+
+import { versionsPath } from "../constants.ts";
+
+const compareVersionsDesc = (first: string, second: string) => {
+  const [firstMajor, firstMinor] = first.split(".").map(Number);
+  const [secondMajor, secondMinor] = second.split(".").map(Number);
+
+  if (firstMajor === secondMajor) {
+    return secondMinor - firstMinor;
+  }
+
+  return secondMajor - firstMajor;
+};
+
+const findLatestInstalledVersion = async (): Promise<string | undefined> => {
+  if (!await exists(versionsPath)) {
+    return undefined;
+  }
+
+  const directories = await Array.fromAsync(Deno.readDir(versionsPath));
+
+  return directories
+    .filter((entry) => entry.isDirectory)
+    .map((entry) => entry.name)
+    .toSorted(compareVersionsDesc)[0];
+};
+
+const extractEntry = (
+  changelog: string,
+  version: string,
+): string | undefined => {
+  const lines = changelog.split("\n");
+  const escapedVersion = version.replace(/\./g, "\\.");
+  const headerPattern = new RegExp(`^\\* ${escapedVersion}\\s*$`);
+
+  const startIndex = lines.findIndex((line) => headerPattern.test(line));
+
+  if (startIndex === -1) {
+    return undefined;
+  }
+
+  let endIndex = lines.length;
+  for (let index = startIndex + 1; index < lines.length; index++) {
+    if (/^\* \d/.test(lines[index])) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join("\n").trimEnd();
+};
+
+export default async function changelog(version?: string) {
+  const sourceVersion = await findLatestInstalledVersion();
+
+  if (!sourceVersion) {
+    throw new Error("drenv: no DragonRuby versions installed");
+  }
+
+  const changelogPath = `${versionsPath}/${sourceVersion}/CHANGELOG-CURR.txt`;
+
+  if (!await exists(changelogPath)) {
+    throw new Error(`drenv: changelog not found at ${changelogPath}`);
+  }
+
+  const target = version ?? sourceVersion;
+  const content = await Deno.readTextFile(changelogPath);
+  const entry = extractEntry(content, target);
+
+  if (!entry) {
+    throw new Error(`drenv: no changelog entry found for version ${target}`);
+  }
+
+  return entry;
+}

--- a/commands/versions.ts
+++ b/commands/versions.ts
@@ -1,20 +1,21 @@
 import { readVersion } from "../utils/read-version.ts";
+import { getLatestAvailableVersion } from "../utils/latest-version.ts";
 import { versionsPath } from "../constants.ts";
+
+const compareVersions = (first: string, second: string) => {
+  const [firstMajor, firstMinor] = first.split(".").map(Number);
+  const [secondMajor, secondMinor] = second.split(".").map(Number);
+
+  if (firstMajor === secondMajor) {
+    return firstMinor - secondMinor;
+  }
+
+  return firstMajor - secondMajor;
+};
 
 export default async function versions() {
   const directories = (await Array.fromAsync(Deno.readDir(versionsPath)))
-    .toSorted(
-      (first, second) => {
-        const [secondMajor, secondMinor] = second.name.split(".").map(Number);
-        const [firstMajor, firstMinor] = first.name.split(".").map(Number);
-
-        if (firstMajor == secondMajor) {
-          return secondMinor - firstMinor;
-        }
-
-        return (secondMajor - firstMajor);
-      },
-    );
+    .toSorted((first, second) => compareVersions(second.name, first.name));
 
   const currentVersion = await readVersion("./CHANGELOG-CURR.txt");
 
@@ -24,5 +25,17 @@ export default async function versions() {
     } else {
       console.log("  " + directory.name);
     }
+  }
+
+  const latestAvailable = await getLatestAvailableVersion();
+  const latestInstalled = directories[0]?.name;
+
+  if (
+    latestAvailable && latestInstalled &&
+    compareVersions(latestAvailable, latestInstalled) > 0
+  ) {
+    console.log(
+      `v${latestAvailable} is available. \`drenv install\` to install`,
+    );
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,16 +2,25 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@*": "1.0.6",
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/assert@^1.0.6": "1.0.6",
     "jsr:@std/cli@*": "1.0.6",
     "jsr:@std/cli@^1.0.12": "1.0.12",
+    "jsr:@std/fs@^1.0.11": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/internal@^1.0.4": "1.0.4",
     "jsr:@std/path@^1.0.6": "1.0.6",
+    "jsr:@std/path@^1.0.8": "1.1.4",
+    "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@*": "1.0.3",
     "jsr:@std/semver@^1.0.3": "1.0.3",
     "jsr:@std/testing@*": "1.0.3",
+    "jsr:@std/testing@^1.0.9": "1.0.18",
     "jsr:@zip-js/zip-js@*": "2.7.54",
     "jsr:@zip-js/zip-js@^2.7.54": "2.7.54",
+    "jsr:@zip-js/zip-js@^2.7.57": "2.8.24",
     "npm:commander@^13.1.0": "13.1.0",
     "npm:ora@*": "8.1.1",
     "npm:ora@^8.1.1": "8.1.1"
@@ -20,7 +29,13 @@
     "@std/assert@1.0.6": {
       "integrity": "1904c05806a25d94fe791d6d883b685c9e2dcd60e4f9fc30f4fc5cf010c72207",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.4"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/cli@1.0.6": {
@@ -32,14 +47,33 @@
     "@std/fs@1.0.4": {
       "integrity": "2907d32d8d1d9e540588fd5fe0ec21ee638134bd51df327ad4e443aaef07123c",
       "dependencies": [
-        "jsr:@std/path"
+        "jsr:@std/path@^1.0.6"
+      ]
+    },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/path@^1.1.4"
       ]
     },
     "@std/internal@1.0.4": {
       "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
     },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
     "@std/path@1.0.6": {
       "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
     },
     "@std/semver@1.0.3": {
       "integrity": "7c139c6076a080eeaa4252c78b95ca5302818d7eafab0470d34cafd9930c13c8"
@@ -48,11 +82,21 @@
       "integrity": "f98c2bee53860a5916727d7e7d3abe920dd6f9edace022e2d059f00d05c2cf42",
       "dependencies": [
         "jsr:@std/assert@^1.0.6",
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.4"
+      ]
+    },
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/internal@^1.0.13"
       ]
     },
     "@zip-js/zip-js@2.7.54": {
       "integrity": "a28b93b56a6cb2ed0f613355b2e9120ea9f6e9703dd6ae1bbc0088cfa3fef692"
+    },
+    "@zip-js/zip-js@2.8.24": {
+      "integrity": "3e5744893e2b08f82ec3706ffad05398ee03ab2628457d805e449efda354994b"
     }
   },
   "npm": {

--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@ import { Argument, Command } from "commander";
 import config from "./deno.json" with { type: "json" };
 
 import add from "./commands/add.ts";
+import changelog from "./commands/changelog.ts";
 import global from "./commands/global.ts";
 import install from "./commands/install.ts";
 import update from "./commands/update.ts";
@@ -68,6 +69,14 @@ program
   .argument("[version]", "Version of DragonRuby to use")
   .description("Get or set the local version of DragonRuby")
   .action(actionRunner(update));
+
+program
+  .command("changelog")
+  .argument("[version]", "Version of DragonRuby to print the changelog for")
+  .description(
+    "Print the changelog entry for a version (defaults to the latest installed)",
+  )
+  .action(actionRunner(changelog));
 
 program
   .command("versions")

--- a/utils/latest-version.test.ts
+++ b/utils/latest-version.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertEquals } from "@std/assert";
+
+import { getLatestAvailableVersion } from "./latest-version.ts";
+
+describe("getLatestAvailableVersion", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("when the response is a version string", () => {
+    beforeEach(() => {
+      globalThis.fetch = () =>
+        Promise.resolve(new Response("6.57\n", { status: 200 }));
+    });
+
+    it("returns the trimmed version", async () => {
+      const result = await getLatestAvailableVersion();
+
+      assertEquals(result, "6.57");
+    });
+  });
+
+  describe("when the response body is not a version", () => {
+    beforeEach(() => {
+      globalThis.fetch = () =>
+        Promise.resolve(new Response("<html>oops</html>", { status: 200 }));
+    });
+
+    it("returns undefined", async () => {
+      const result = await getLatestAvailableVersion();
+
+      assertEquals(result, undefined);
+    });
+  });
+
+  describe("when the response is not ok", () => {
+    beforeEach(() => {
+      globalThis.fetch = () =>
+        Promise.resolve(new Response("Not Found", { status: 404 }));
+    });
+
+    it("returns undefined", async () => {
+      const result = await getLatestAvailableVersion();
+
+      assertEquals(result, undefined);
+    });
+  });
+
+  describe("when fetch throws", () => {
+    beforeEach(() => {
+      globalThis.fetch = () => Promise.reject(new Error("offline"));
+    });
+
+    it("returns undefined", async () => {
+      const result = await getLatestAvailableVersion();
+
+      assertEquals(result, undefined);
+    });
+  });
+});

--- a/utils/latest-version.ts
+++ b/utils/latest-version.ts
@@ -1,0 +1,17 @@
+const VERSION_URL = "https://docs.dragonruby.org/version.txt";
+
+export const getLatestAvailableVersion = async (): Promise<
+  string | undefined
+> => {
+  try {
+    const res = await fetch(VERSION_URL);
+
+    if (!res.ok) return undefined;
+
+    const version = (await res.text()).trim();
+
+    return /^\d+\.\d+/.test(version) ? version : undefined;
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
## Summary
- `drenv changelog [version]` — prints the changelog entry for a target version, or the latest installed version when no argument is given. Extracts the entry from the newest installed version's `CHANGELOG-CURR.txt`.
- `drenv versions` now appends `vX.Y is available. \`drenv install\` to install` when `https://docs.dragonruby.org/version.txt` reports a newer version than the highest installed locally. The check fails open, so the command keeps working when offline.

## Test plan
- [ ] `deno test -A` passes (3 suites, 22 steps)
- [ ] `drenv changelog` with nothing installed errors with `no DragonRuby versions installed`
- [ ] `drenv changelog` prints the latest installed version's entry
- [ ] `drenv changelog 6.21` prints that specific entry
- [ ] `drenv changelog 999.999` errors with `no changelog entry found for version 999.999`
- [ ] `drenv versions` shows no notification when up to date
- [ ] `drenv versions` shows the upgrade notice when a stale version is the latest installed
- [ ] `drenv versions` still prints the list when offline (no error, no notice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)