### PR TITLE
Add deno task release for cutting versioned releases

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "version": "0.6.0",
   "tasks": {
     "dev": "deno run --watch main.ts",
+    "release": "deno run -A scripts/release.ts",
     "compile": "deno compile -A --unstable-kv --output=builds/ main.ts",
     "compile:windows-x86": "deno compile -A --output=builds/x86_64-pc-windows-msvc.drenv --target=x86_64-pc-windows-msvc main.ts",
     "compile:macos-x86": "deno compile -A --output=builds/x86_64-apple-darwin.drenv --target=x86_64-apple-darwin main.ts",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,65 @@
+import config from "../deno.json" with { type: "json" };
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+const fail = (message: string): never => {
+  console.error(message);
+  Deno.exit(1);
+};
+
+const run = async (cmd: string, args: string[]) => {
+  const { success } = await new Deno.Command(cmd, {
+    args,
+    stdout: "inherit",
+    stderr: "inherit",
+  }).output();
+
+  if (!success) {
+    fail(`drenv: \`${cmd} ${args.join(" ")}\` failed`);
+  }
+};
+
+const capture = async (cmd: string, args: string[]) => {
+  const { stdout } = await new Deno.Command(cmd, { args }).output();
+  return new TextDecoder().decode(stdout).trim();
+};
+
+const [version] = Deno.args;
+
+if (!version || !VERSION_PATTERN.test(version)) {
+  fail("Usage: deno task release <X.Y.Z>");
+}
+
+if (version === config.version) {
+  fail(`drenv: deno.json is already on version ${version}`);
+}
+
+const branch = await capture("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+if (branch !== "main") {
+  fail(`drenv: refusing to release from branch \`${branch}\` (must be main)`);
+}
+
+const status = await capture("git", ["status", "--porcelain"]);
+if (status) {
+  fail("drenv: working tree is not clean — commit or stash changes first");
+}
+
+const denoJsonPath = new URL("../deno.json", import.meta.url);
+const original = await Deno.readTextFile(denoJsonPath);
+const updated = original.replace(
+  /"version":\s*"[^"]+"/,
+  `"version": "${version}"`,
+);
+
+if (updated === original) {
+  fail("drenv: failed to rewrite version field in deno.json");
+}
+
+await Deno.writeTextFile(denoJsonPath, updated);
+
+await run("git", ["add", "deno.json"]);
+await run("git", ["commit", "-m", `Bump to version v${version}`]);
+await run("git", ["tag", `v${version}`]);
+await run("git", ["push", "origin", "main", `v${version}`]);
+
+console.log(`drenv: released v${version}`);


### PR DESCRIPTION
## Summary
- New `scripts/release.ts` and `release` entry under `tasks` in `deno.json`.
- `deno task release X.Y.Z` rewrites `version` in `deno.json`, commits as `Bump to version vX.Y.Z`, tags `vX.Y.Z`, and pushes the commit and tag together. The tag push is what fires the existing release workflow.
- Refuses to run if the working tree is dirty, the current branch isn't `main`, the version arg is missing/malformed, or the requested version already matches `deno.json`.

## Test plan
- [ ] `deno task release` (no args) prints usage and exits non-zero
- [ ] `deno task release abc` prints usage and exits non-zero
- [ ] `deno task release 0.7.0` from a feature branch refuses with a `must be main` error
- [ ] `deno task release 0.6.0` (current version) refuses with `already on version`
- [ ] `deno task release 0.7.0` from a clean main bumps `deno.json`, commits, tags, and pushes — and the resulting tag push triggers the release workflow on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)