### PR TITLE
Print drenv update notice after every command

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           deno-version: v2.x
       - name: Run Tests
-        run: deno test -A
+        run: deno test -A --unstable-kv
 
   build:
     strategy:

--- a/commands/versions.ts
+++ b/commands/versions.ts
@@ -14,8 +14,15 @@ const compareVersions = (first: string, second: string) => {
 };
 
 export default async function versions() {
-  const directories = (await Array.fromAsync(Deno.readDir(versionsPath)))
-    .toSorted((first, second) => compareVersions(second.name, first.name));
+  let directories: Deno.DirEntry[] = [];
+  try {
+    directories = await Array.fromAsync(Deno.readDir(versionsPath));
+  } catch (_err) {
+    // No versions installed yet
+  }
+  directories = directories.toSorted((first, second) =>
+    compareVersions(second.name, first.name)
+  );
 
   const currentVersion = await readVersion("./CHANGELOG-CURR.txt");
 

--- a/main.ts
+++ b/main.ts
@@ -44,7 +44,7 @@ const actionRunner = (
         console.log(value);
       }
     } catch (error) {
-      console.error((error as Error).message);
+      console.error(error instanceof Error ? error.message : String(error));
     } finally {
       if (!options.skipUpdateCheck) {
         await printDrenvUpdateNotice();

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { Argument, Command } from "commander";
+import { greaterThan, tryParse } from "@std/semver";
 
 import config from "./deno.json" with { type: "json" };
 
@@ -13,18 +14,43 @@ import setup from "./commands/setup.ts";
 import upgrade from "./commands/upgrade.ts";
 import versions from "./commands/versions.ts";
 
+import { getLatestDrenvVersion } from "./utils/latest-drenv-version.ts";
+
 export const program = new Command();
 
-const actionRunner = (fn: (...args: string[]) => Promise<unknown>) => {
-  return (...args: string[]): void | Promise<void> =>
-    fn(...args)
-      .then(
-        (value) => {
-          (typeof value === "string" || typeof value === "number") &&
-            console.log(value);
-        },
-      )
-      .catch((error) => console.error(error.message));
+const printDrenvUpdateNotice = async () => {
+  const latest = await getLatestDrenvVersion();
+  if (!latest) return;
+
+  const latestParsed = tryParse(latest);
+  const currentParsed = tryParse(config.version);
+  if (!latestParsed || !currentParsed) return;
+
+  if (greaterThan(latestParsed, currentParsed)) {
+    console.log(
+      `drenv update available. \`drenv upgrade\` to install v${latest}`,
+    );
+  }
+};
+
+const actionRunner = (
+  fn: (...args: string[]) => Promise<unknown>,
+  options: { skipUpdateCheck?: boolean } = {},
+) => {
+  return async (...args: string[]): Promise<void> => {
+    try {
+      const value = await fn(...args);
+      if (typeof value === "string" || typeof value === "number") {
+        console.log(value);
+      }
+    } catch (error) {
+      console.error((error as Error).message);
+    } finally {
+      if (!options.skipUpdateCheck) {
+        await printDrenvUpdateNotice();
+      }
+    }
+  };
 };
 
 program
@@ -86,7 +112,7 @@ program
 program
   .command("upgrade")
   .description("Upgrade the version of drenv")
-  .action(actionRunner(upgrade));
+  .action(actionRunner(upgrade, { skipUpdateCheck: true }));
 
 program
   .command("install")

--- a/utils/latest-drenv-version.test.ts
+++ b/utils/latest-drenv-version.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertEquals } from "@std/assert";
+
+import {
+  fetchLatestDrenvVersion,
+  getLatestDrenvVersion,
+} from "./latest-drenv-version.ts";
+
+const originalFetch = globalThis.fetch;
+
+const stubFetch = (response: Response | (() => Promise<Response>)) => {
+  globalThis.fetch = typeof response === "function"
+    ? (() => response()) as typeof fetch
+    : (() => Promise.resolve(response)) as typeof fetch;
+};
+
+const stubFetchReject = (error: Error) => {
+  globalThis.fetch = (() => Promise.reject(error)) as typeof fetch;
+};
+
+const restoreFetch = () => {
+  globalThis.fetch = originalFetch;
+};
+
+describe("fetchLatestDrenvVersion", () => {
+  afterEach(restoreFetch);
+
+  describe("when the response carries a tag_name", () => {
+    beforeEach(() => {
+      stubFetch(
+        new Response(JSON.stringify({ tag_name: "v0.7.0" }), { status: 200 }),
+      );
+    });
+
+    it("returns the version with the v prefix stripped", async () => {
+      assertEquals(await fetchLatestDrenvVersion(), "0.7.0");
+    });
+  });
+
+  describe("when tag_name has no v prefix", () => {
+    beforeEach(() => {
+      stubFetch(
+        new Response(JSON.stringify({ tag_name: "0.7.0" }), { status: 200 }),
+      );
+    });
+
+    it("returns the tag as-is", async () => {
+      assertEquals(await fetchLatestDrenvVersion(), "0.7.0");
+    });
+  });
+
+  describe("when tag_name is missing", () => {
+    beforeEach(() => {
+      stubFetch(new Response(JSON.stringify({}), { status: 200 }));
+    });
+
+    it("returns undefined", async () => {
+      assertEquals(await fetchLatestDrenvVersion(), undefined);
+    });
+  });
+
+  describe("when tag_name is malformed", () => {
+    beforeEach(() => {
+      stubFetch(
+        new Response(JSON.stringify({ tag_name: "vNEXT" }), { status: 200 }),
+      );
+    });
+
+    it("returns undefined", async () => {
+      assertEquals(await fetchLatestDrenvVersion(), undefined);
+    });
+  });
+
+  describe("when the response is not ok", () => {
+    beforeEach(() => {
+      stubFetch(new Response("rate limited", { status: 403 }));
+    });
+
+    it("returns undefined", async () => {
+      assertEquals(await fetchLatestDrenvVersion(), undefined);
+    });
+  });
+
+  describe("when fetch throws", () => {
+    beforeEach(() => {
+      stubFetchReject(new Error("offline"));
+    });
+
+    it("returns undefined", async () => {
+      assertEquals(await fetchLatestDrenvVersion(), undefined);
+    });
+  });
+});
+
+describe("getLatestDrenvVersion", () => {
+  let kv: Deno.Kv;
+
+  beforeEach(async () => {
+    kv = await Deno.openKv(":memory:");
+  });
+
+  afterEach(() => {
+    kv.close();
+    restoreFetch();
+  });
+
+  describe("when the cache is empty", () => {
+    beforeEach(() => {
+      stubFetch(
+        new Response(JSON.stringify({ tag_name: "v0.7.0" }), { status: 200 }),
+      );
+    });
+
+    it("fetches and stores the version", async () => {
+      assertEquals(await getLatestDrenvVersion(kv), "0.7.0");
+
+      const stored = (await kv.get(["drenv", "latestVersion"])).value as
+        | { version: string }
+        | null;
+      assertEquals(stored?.version, "0.7.0");
+    });
+  });
+
+  describe("when the cache is fresh", () => {
+    beforeEach(async () => {
+      await kv.set(["drenv", "latestVersion"], {
+        version: "0.6.0",
+        checkedAt: Date.now(),
+      });
+      stubFetchReject(new Error("must not be called"));
+    });
+
+    it("returns the cached value without fetching", async () => {
+      assertEquals(await getLatestDrenvVersion(kv), "0.6.0");
+    });
+  });
+
+  describe("when the cache is stale", () => {
+    beforeEach(async () => {
+      await kv.set(["drenv", "latestVersion"], {
+        version: "0.5.0",
+        checkedAt: Date.now() - 25 * 60 * 60 * 1000,
+      });
+      stubFetch(
+        new Response(JSON.stringify({ tag_name: "v0.7.0" }), { status: 200 }),
+      );
+    });
+
+    it("refetches and updates the cache", async () => {
+      assertEquals(await getLatestDrenvVersion(kv), "0.7.0");
+
+      const stored = (await kv.get(["drenv", "latestVersion"])).value as
+        | { version: string }
+        | null;
+      assertEquals(stored?.version, "0.7.0");
+    });
+  });
+
+  describe("when the cache is stale and fetch fails", () => {
+    beforeEach(async () => {
+      await kv.set(["drenv", "latestVersion"], {
+        version: "0.5.0",
+        checkedAt: Date.now() - 25 * 60 * 60 * 1000,
+      });
+      stubFetchReject(new Error("offline"));
+    });
+
+    it("returns the stale cached value", async () => {
+      assertEquals(await getLatestDrenvVersion(kv), "0.5.0");
+    });
+  });
+
+  describe("when there is no cache and fetch fails", () => {
+    beforeEach(() => {
+      stubFetchReject(new Error("offline"));
+    });
+
+    it("returns undefined", async () => {
+      assertEquals(await getLatestDrenvVersion(kv), undefined);
+    });
+  });
+});

--- a/utils/latest-drenv-version.ts
+++ b/utils/latest-drenv-version.ts
@@ -1,0 +1,65 @@
+import { homePath } from "../constants.ts";
+
+const RELEASES_URL =
+  "https://api.github.com/repos/nitemaeric/drenv/releases/latest";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 2000;
+
+type CachedVersion = { version: string; checkedAt: number };
+
+export const fetchLatestDrenvVersion = async (): Promise<
+  string | undefined
+> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(RELEASES_URL, { signal: controller.signal });
+    if (!res.ok) return undefined;
+
+    const data = await res.json();
+    const tag = data.tag_name as string | undefined;
+    if (!tag) return undefined;
+
+    const version = tag.startsWith("v") ? tag.slice(1) : tag;
+    return /^\d+\.\d+\.\d+/.test(version) ? version : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+export const getLatestDrenvVersion = async (
+  kv?: Deno.Kv,
+): Promise<string | undefined> => {
+  const ownsKv = !kv;
+  kv ??= await Deno.openKv(homePath + "/database.db");
+
+  try {
+    const cached = (await kv.get(["drenv", "latestVersion"])).value as
+      | CachedVersion
+      | null;
+
+    if (cached && Date.now() - cached.checkedAt < CACHE_TTL_MS) {
+      return cached.version;
+    }
+
+    const version = await fetchLatestDrenvVersion();
+    if (!version) return cached?.version;
+
+    await kv.set(
+      ["drenv", "latestVersion"],
+      {
+        version,
+        checkedAt: Date.now(),
+      } satisfies CachedVersion,
+    );
+
+    return version;
+  } catch {
+    return undefined;
+  } finally {
+    if (ownsKv) kv.close();
+  }
+};

--- a/utils/latest-drenv-version.ts
+++ b/utils/latest-drenv-version.ts
@@ -34,9 +34,9 @@ export const getLatestDrenvVersion = async (
   kv?: Deno.Kv,
 ): Promise<string | undefined> => {
   const ownsKv = !kv;
-  kv ??= await Deno.openKv(homePath + "/database.db");
-
   try {
+    kv ??= await Deno.openKv(homePath + "/database.db");
+
     const cached = (await kv.get(["drenv", "latestVersion"])).value as
       | CachedVersion
       | null;
@@ -60,6 +60,6 @@ export const getLatestDrenvVersion = async (
   } catch {
     return undefined;
   } finally {
-    if (ownsKv) kv.close();
+    if (ownsKv && kv) kv.close();
   }
 };


### PR DESCRIPTION
## Summary
- New `utils/latest-drenv-version.ts` helper. `fetchLatestDrenvVersion` hits `https://api.github.com/repos/nitemaeric/drenv/releases/latest` with a 2s `AbortController` timeout, returns the trimmed semver (or `undefined`). `getLatestDrenvVersion(kv?)` wraps it with a 24h cache in the existing `~/.drenv/database.db`; on a stale-cache + fetch-failure it falls back to the stale value so offline commands keep working.
- `actionRunner` in `main.ts` now runs an async `printDrenvUpdateNotice` step in a `finally` block, comparing the running version against the cached/fetched latest with `@std/semver`. When the remote is greater it prints `` drenv update available. `drenv upgrade` to install vX.Y.Z ``.
- The `upgrade` command opts out via `actionRunner(upgrade, { skipUpdateCheck: true })` so we don't print a stale notice immediately after a successful upgrade.

## Test plan
- [x] `deno test -A --unstable-kv` passes — 5 suites, 44 steps
- [x] Manually verified that `drenv versions` does **not** print the notice when `deno.json` matches the latest release
- [x] Manually verified that `drenv versions` **does** print `` drenv update available. `drenv upgrade` to install v0.6.0 `` after lowering `deno.json` version to `0.5.0`
- [ ] After release of v0.7.0 (or later), confirm the notice fires for users still on v0.6.0
- [ ] Confirm `drenv upgrade` itself does not print the notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)