### PR TITLE
feat: resolve library entrypoints automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,25 +117,24 @@ matching `require` lines.
 
 ```toml
 # mygame/drenv.toml
+[dependencies.conjuration]
+github = "Nitemaeric/conjuration"   # entrypoint resolved from the library
+
 [dependencies.draco]
 github = "guitsaru/draco"
 tag = "v0.7.0"
-entrypoint = "draco.rb"
-
-[dependencies.my_engine]
-git = "https://gitlab.com/me/my_engine.git"
-branch = "main"
-entrypoint = "lib/my_engine.rb"
+entrypoint = "draco.rb"             # ...or pin it explicitly
 
 [dependencies.local_lib]
 path = "../local_lib"
-entrypoint = "lib/local_lib.rb"
 ```
 
-Each dependency declares exactly one source — `github`, `url`, `git`, or `path`
-— plus the `entrypoint` to load. You can edit `drenv.toml` by hand or manage it
-with `drenv add` / `drenv remove`. Either way, add a single line to the top of
-`mygame/app/main.rb`:
+Each dependency declares exactly one source — `github`, `url`, `git`, or `path`.
+The `entrypoint` is optional: drenv resolves it from the library's own
+[`[package]`](#publishing-a-library) declaration, or by convention
+(`lib/<name>.rb`, then `<name>.rb`). You can edit `drenv.toml` by hand or manage
+it with `drenv add` / `drenv remove`. Either way, add a single line to the top
+of `mygame/app/main.rb`:
 
 ```ruby
 require 'app/drenv_bundle.rb'
@@ -150,14 +149,14 @@ Adds a dependency to `mygame/drenv.toml` and vendors it. The source is
 `kind:value`:
 
 ```sh
-drenv add github:guitsaru/draco@v0.7.0 -e draco.rb
-drenv add git:https://gitlab.com/me/my_engine.git --branch main -e lib/my_engine.rb
-drenv add url:https://example.com/scene_manager.rb
-drenv add path:../local_lib -e lib/local_lib.rb
+drenv add github:Nitemaeric/conjuration        # entrypoint resolved for you
+drenv add github:guitsaru/draco@v0.7.0
+drenv add git:https://gitlab.com/me/my_engine.git --branch main
+drenv add path:../local_lib
 ```
 
-Pass `-e, --entrypoint` for the file to require (defaulted from the filename for
-`url:` sources), `-n, --name` to override the derived name, and
+Pass `-e, --entrypoint` only when the library doesn't declare or follow a
+conventional entrypoint, `-n, --name` to override the derived name, and
 `--tag`/`--branch`/`--ref` to pin a `github`/`git` revision.
 
 ### `drenv remove <name>`
@@ -180,6 +179,21 @@ Verifies dependencies against the lockfile (like `--frozen`), then runs
 `dragonruby-publish` on `mygame`, forwarding any arguments. So
 `drenv publish --package` packages locally and `drenv publish` publishes to
 itch.io — always shipping exactly what's locked.
+
+### Publishing a library
+
+If you maintain a DragonRuby library, add a `[package]` section to a
+`drenv.toml` at your repo root so consumers can `drenv add` it with no extra
+flags:
+
+```toml
+[package]
+root = "lib"                  # only this directory is vendored (default ".")
+entrypoint = "conjuration.rb" # the file to require, relative to root
+```
+
+Without it, drenv falls back to convention — `lib/<name>.rb`, then `<name>.rb` —
+so many libraries (a `lib/<name>.rb` layout) work with zero configuration.
 
 ## Managing drenv
 

--- a/commands/add.ts
+++ b/commands/add.ts
@@ -8,6 +8,7 @@ import {
   addDependencyToManifest,
   deriveName,
   parseSource,
+  removeDependencyFromManifest,
 } from "../utils/manifest-edit.ts";
 
 type AddOptions = {
@@ -61,14 +62,8 @@ export default async function add(source: string, options: AddOptions = {}) {
   };
   dep[parsed.kind] = value;
 
-  if (parsed.kind !== "url" && !dep.entrypoint) {
-    throw new Error(
-      `drenv: ${parsed.kind} dependencies need an entrypoint — pass \`-e <file>\`` +
-        (parsed.kind === "path"
-          ? " or point at the entry file (e.g. drenv add ../lib/conjuration.rb)"
-          : ""),
-    );
-  }
+  // Entrypoint is optional: github/git/path deps without one are resolved from
+  // the library's [package] declaration or by convention when vendoring.
 
   const existing = await readManifest(project.manifestPath).catch(() => null);
   if (existing?.dependencies.some((d) => d.name === name)) {
@@ -79,9 +74,18 @@ export default async function add(source: string, options: AddOptions = {}) {
 
   await addDependencyToManifest(project.manifestPath, dep);
 
-  const { needsRequireLine } = await bundle(project, {
-    log: (message) => console.log(message),
-  });
+  let needsRequireLine: boolean;
+  try {
+    ({ needsRequireLine } = await bundle(project, {
+      log: (message) => console.log(message),
+    }));
+  } catch (error) {
+    // Roll the manifest back if resolution/vendoring failed, so a bad add
+    // doesn't leave a broken entry behind.
+    await removeDependencyFromManifest(project.manifestPath, name)
+      .catch(() => {});
+    throw error;
+  }
 
   console.log(`drenv: added ${name}`);
 

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.8.1",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "release": "deno run -A scripts/release.ts",

--- a/utils/bundler.test.ts
+++ b/utils/bundler.test.ts
@@ -134,3 +134,68 @@ describe("bundler (path source)", () => {
     );
   });
 });
+
+describe("bundler (library-resolved entrypoint)", () => {
+  let tmp: string;
+  let project: Project;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "drenv-resolve-bundle-" });
+
+    // A library "repo" with code under lib/ and unrelated junk at the root.
+    await ensureDir(join(tmp, "repo", "lib", "mylib"));
+    await Deno.writeTextFile(
+      join(tmp, "repo", "lib", "mylib.rb"),
+      'require_relative "mylib/helper"\n',
+    );
+    await Deno.writeTextFile(
+      join(tmp, "repo", "lib", "mylib", "helper.rb"),
+      "class Helper; end\n",
+    );
+    await Deno.writeTextFile(
+      join(tmp, "repo", "README.md"),
+      "# not vendored\n",
+    );
+
+    const mygame = join(tmp, "game", "mygame");
+    await ensureDir(join(mygame, "app"));
+    // No entrypoint — resolved by convention (lib/<name>.rb).
+    await Deno.writeTextFile(
+      join(mygame, "drenv.toml"),
+      '[dependencies.mylib]\npath = "../../repo"\n',
+    );
+    await Deno.writeTextFile(
+      join(mygame, "app", "main.rb"),
+      "def tick args\nend\n",
+    );
+
+    project = {
+      root: join(tmp, "game"),
+      mygame,
+      manifestPath: join(mygame, "drenv.toml"),
+      lockPath: join(mygame, "drenv.lock"),
+    };
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("resolves the entrypoint by convention and vendors only lib/", async () => {
+    const { lock } = await bundle(project);
+
+    // lib/ contents land at the vendor root...
+    assert(await exists(join(project.mygame, "vendor", "mylib", "mylib.rb")));
+    assert(
+      await exists(
+        join(project.mygame, "vendor", "mylib", "mylib", "helper.rb"),
+      ),
+    );
+    // ...and the repo's junk does not.
+    assertFalse(
+      await exists(join(project.mygame, "vendor", "mylib", "README.md")),
+    );
+
+    assertEquals(lock.dependencies[0].require, ["vendor/mylib/mylib.rb"]);
+  });
+});

--- a/utils/manifest.test.ts
+++ b/utils/manifest.test.ts
@@ -46,6 +46,20 @@ entrypoint = "lib/local_lib.rb"
       "multiple sources",
     );
   });
+
+  it("parses a [package] declaration", () => {
+    const manifest = parseManifest(
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n',
+    );
+    assertEquals(manifest.package, {
+      root: "lib",
+      entrypoint: "conjuration.rb",
+    });
+  });
+
+  it("has no package when none is declared", () => {
+    assertEquals(parseManifest("").package, undefined);
+  });
 });
 
 describe("sourceKind", () => {

--- a/utils/manifest.ts
+++ b/utils/manifest.ts
@@ -16,8 +16,17 @@ export type DependencySpec = {
   ref?: string;
 };
 
+/** A library's self-description, declared in its own `[package]` table. */
+export type PackageSpec = {
+  /** Subdirectory of the source that holds the library (default "."). */
+  root?: string;
+  /** Entrypoint to require, relative to `root`. */
+  entrypoint?: string;
+};
+
 export type Manifest = {
   dependencies: DependencySpec[];
+  package?: PackageSpec;
 };
 
 export class InvalidManifest extends Error {
@@ -53,6 +62,7 @@ export const sourceKind = (spec: DependencySpec): SourceKind => {
 export const parseManifest = (text: string): Manifest => {
   const data = parse(text) as {
     dependencies?: Record<string, Record<string, unknown>>;
+    package?: PackageSpec;
   };
 
   const dependencies = Object.entries(data.dependencies ?? {}).map(
@@ -64,7 +74,7 @@ export const parseManifest = (text: string): Manifest => {
     sourceKind(spec);
   }
 
-  return { dependencies };
+  return { dependencies, package: data.package };
 };
 
 export const readManifest = async (path: string): Promise<Manifest> => {

--- a/utils/sources/git.ts
+++ b/utils/sources/git.ts
@@ -1,16 +1,7 @@
-import { exists } from "@std/fs";
-import { join } from "@std/path";
-
 import type { DependencySpec } from "../manifest.ts";
 import type { LockedDependency } from "../lockfile.ts";
-import { copyTree } from "../copy-tree.ts";
 import { treeDigest } from "../integrity.ts";
-import {
-  requireEntrypoint,
-  type VendorContext,
-  vendorDir,
-  vendorRequire,
-} from "./mod.ts";
+import { stageIntoVendor, type VendorContext, vendorDir } from "./resolve.ts";
 
 const git = async (
   args: string[],
@@ -39,7 +30,6 @@ export const vendorGit = async (
   spec: DependencySpec,
   ctx: VendorContext,
 ): Promise<LockedDependency> => {
-  const entrypoint = requireEntrypoint(spec);
   const url = spec.git!;
   const named = spec.tag ?? spec.branch;
 
@@ -82,15 +72,7 @@ export const vendorGit = async (
 
     const { stdout: sha } = await git(["-C", tmp, "rev-parse", "HEAD"]);
 
-    const dest = vendorDir(ctx, spec.name);
-    await Deno.remove(dest, { recursive: true }).catch(() => {});
-    await copyTree(tmp, dest);
-
-    if (!await exists(join(dest, entrypoint))) {
-      throw new Error(
-        `drenv: entrypoint '${entrypoint}' not found in dependency '${spec.name}'`,
-      );
-    }
+    const require = await stageIntoVendor(tmp, ctx, spec.name, spec.entrypoint);
 
     ctx.log(`drenv: vendored ${spec.name} (git:${url})`);
 
@@ -98,8 +80,8 @@ export const vendorGit = async (
       name: spec.name,
       source: `git:${url}`,
       ref: sha || undefined,
-      require: [vendorRequire(spec.name, entrypoint)],
-      integrity: await treeDigest(dest),
+      require: [require],
+      integrity: await treeDigest(vendorDir(ctx, spec.name)),
     };
   } finally {
     await Deno.remove(tmp, { recursive: true }).catch(() => {});

--- a/utils/sources/github.ts
+++ b/utils/sources/github.ts
@@ -1,16 +1,11 @@
-import { ensureDir, exists } from "@std/fs";
+import { ensureDir } from "@std/fs";
 import { dirname, join } from "@std/path";
 import { configure, ZipReaderStream } from "@zip-js/zip-js";
 
 import type { DependencySpec } from "../manifest.ts";
 import type { LockedDependency } from "../lockfile.ts";
 import { treeDigest } from "../integrity.ts";
-import {
-  requireEntrypoint,
-  type VendorContext,
-  vendorDir,
-  vendorRequire,
-} from "./mod.ts";
+import { stageIntoVendor, type VendorContext, vendorDir } from "./resolve.ts";
 
 configure({ useWebWorkers: false });
 
@@ -35,7 +30,6 @@ export const vendorGithub = async (
   spec: DependencySpec,
   ctx: VendorContext,
 ): Promise<LockedDependency> => {
-  const entrypoint = requireEntrypoint(spec);
   const [owner, repo] = spec.github!.split("/");
 
   if (!owner || !repo) {
@@ -56,36 +50,42 @@ export const vendorGithub = async (
     );
   }
 
-  const dest = vendorDir(ctx, spec.name);
-  await Deno.remove(dest, { recursive: true }).catch(() => {});
+  const staging = await Deno.makeTempDir({ prefix: "drenv-gh-" });
 
-  for await (const entry of response.body.pipeThrough(new ZipReaderStream())) {
-    if (entry.directory) continue;
+  try {
+    for await (
+      const entry of response.body.pipeThrough(new ZipReaderStream())
+    ) {
+      if (entry.directory) continue;
 
-    // GitHub archives nest everything under a `<repo>-<ref>/` directory.
-    const inner = entry.filename.split("/").slice(1).join("/");
-    if (!inner || inner.endsWith(".DS_Store")) continue;
+      // GitHub archives nest everything under a `<repo>-<ref>/` directory.
+      const inner = entry.filename.split("/").slice(1).join("/");
+      if (!inner || inner.endsWith(".DS_Store")) continue;
 
-    const target = join(dest, inner);
-    await ensureDir(dirname(target));
-    await entry.readable?.pipeTo((await Deno.create(target)).writable);
-  }
+      const target = join(staging, inner);
+      await ensureDir(dirname(target));
+      await entry.readable?.pipeTo((await Deno.create(target)).writable);
+    }
 
-  if (!await exists(join(dest, entrypoint))) {
-    throw new Error(
-      `drenv: entrypoint '${entrypoint}' not found in dependency '${spec.name}'`,
+    const require = await stageIntoVendor(
+      staging,
+      ctx,
+      spec.name,
+      spec.entrypoint,
     );
+
+    ctx.log(
+      `drenv: vendored ${spec.name} (github:${spec.github}@${downloadRef})`,
+    );
+
+    return {
+      name: spec.name,
+      source: `github:${spec.github}`,
+      ref: sha ?? downloadRef,
+      require: [require],
+      integrity: await treeDigest(vendorDir(ctx, spec.name)),
+    };
+  } finally {
+    await Deno.remove(staging, { recursive: true }).catch(() => {});
   }
-
-  ctx.log(
-    `drenv: vendored ${spec.name} (github:${spec.github}@${downloadRef})`,
-  );
-
-  return {
-    name: spec.name,
-    source: `github:${spec.github}`,
-    ref: sha ?? downloadRef,
-    require: [vendorRequire(spec.name, entrypoint)],
-    integrity: await treeDigest(dest),
-  };
 };

--- a/utils/sources/mod.ts
+++ b/utils/sources/mod.ts
@@ -1,10 +1,4 @@
-import { join } from "@std/path";
-
-import {
-  type DependencySpec,
-  InvalidManifest,
-  sourceKind,
-} from "../manifest.ts";
+import { type DependencySpec, sourceKind } from "../manifest.ts";
 import type { LockedDependency } from "../lockfile.ts";
 
 import { vendorGit } from "./git.ts";
@@ -12,33 +6,8 @@ import { vendorGithub } from "./github.ts";
 import { vendorPath } from "./path.ts";
 import { vendorUrl } from "./url.ts";
 
-export type VendorContext = {
-  /** Absolute path to the project's `mygame` directory. */
-  mygame: string;
-  /** Absolute directory the manifest lives in (resolves `path:` specs). */
-  manifestDir: string;
-  /** Progress logger. */
-  log: (message: string) => void;
-};
-
-/** Absolute path of a dependency's vendor directory. */
-export const vendorDir = (ctx: VendorContext, name: string): string =>
-  join(ctx.mygame, "vendor", name);
-
-/** A require path (relative to `mygame`) into a dependency's vendor directory. */
-export const vendorRequire = (name: string, entrypoint: string): string =>
-  `vendor/${name}/${entrypoint}`;
-
-/** Asserts a dependency declares an entrypoint and returns it. */
-export const requireEntrypoint = (spec: DependencySpec): string => {
-  if (!spec.entrypoint) {
-    throw new InvalidManifest(
-      `dependency '${spec.name}' must declare an entrypoint`,
-    );
-  }
-
-  return spec.entrypoint;
-};
+export type { VendorContext } from "./resolve.ts";
+import type { VendorContext } from "./resolve.ts";
 
 export const vendorDependency = (
   spec: DependencySpec,

--- a/utils/sources/path.ts
+++ b/utils/sources/path.ts
@@ -1,21 +1,14 @@
 import { exists } from "@std/fs";
-import { join, resolve } from "@std/path";
+import { resolve } from "@std/path";
 
 import type { DependencySpec } from "../manifest.ts";
 import type { LockedDependency } from "../lockfile.ts";
-import { copyTree } from "../copy-tree.ts";
-import {
-  requireEntrypoint,
-  type VendorContext,
-  vendorDir,
-  vendorRequire,
-} from "./mod.ts";
+import { stageIntoVendor, type VendorContext } from "./resolve.ts";
 
 export const vendorPath = async (
   spec: DependencySpec,
   ctx: VendorContext,
 ): Promise<LockedDependency> => {
-  const entrypoint = requireEntrypoint(spec);
   const source = resolve(ctx.manifestDir, spec.path!);
 
   if (!await exists(source)) {
@@ -24,23 +17,20 @@ export const vendorPath = async (
     );
   }
 
-  const dest = vendorDir(ctx, spec.name);
-  // Mirror the source. DragonRuby's sandboxed loader can't follow symlinks out
-  // of the game directory, so path deps are copied fresh on every sync.
-  await Deno.remove(dest, { recursive: true }).catch(() => {});
-  await copyTree(source, dest);
-
-  if (!await exists(join(dest, entrypoint))) {
-    throw new Error(
-      `drenv: entrypoint '${entrypoint}' not found in dependency '${spec.name}'`,
-    );
-  }
+  // DragonRuby's sandboxed loader can't follow symlinks out of the game
+  // directory, so path deps are copied fresh (by stageIntoVendor) on every sync.
+  const require = await stageIntoVendor(
+    source,
+    ctx,
+    spec.name,
+    spec.entrypoint,
+  );
 
   ctx.log(`drenv: vendored ${spec.name} (path:${spec.path})`);
 
   return {
     name: spec.name,
     source: `path:${spec.path}`,
-    require: [vendorRequire(spec.name, entrypoint)],
+    require: [require],
   };
 };

--- a/utils/sources/resolve.test.ts
+++ b/utils/sources/resolve.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertEquals, assertRejects } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+import { resolveEntrypoint } from "./resolve.ts";
+
+describe("resolveEntrypoint", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "drenv-resolve-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("uses an explicit override, rooted at the fetched tree", async () => {
+    assertEquals(
+      await resolveEntrypoint(tmp, "conjuration", "lib/conjuration.rb"),
+      { root: ".", entrypoint: "lib/conjuration.rb" },
+    );
+  });
+
+  it("reads the library's [package] declaration", async () => {
+    await Deno.writeTextFile(
+      join(tmp, "drenv.toml"),
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n',
+    );
+
+    assertEquals(await resolveEntrypoint(tmp, "conjuration"), {
+      root: "lib",
+      entrypoint: "conjuration.rb",
+    });
+  });
+
+  it("defaults the [package] root to '.'", async () => {
+    await Deno.writeTextFile(
+      join(tmp, "drenv.toml"),
+      '[package]\nentrypoint = "main.rb"\n',
+    );
+
+    assertEquals(await resolveEntrypoint(tmp, "x"), {
+      root: ".",
+      entrypoint: "main.rb",
+    });
+  });
+
+  it("falls back to lib/<name>.rb by convention", async () => {
+    await ensureDir(join(tmp, "lib"));
+    await Deno.writeTextFile(join(tmp, "lib", "conjuration.rb"), "");
+
+    assertEquals(await resolveEntrypoint(tmp, "conjuration"), {
+      root: "lib",
+      entrypoint: "conjuration.rb",
+    });
+  });
+
+  it("falls back to <name>.rb at the root", async () => {
+    await Deno.writeTextFile(join(tmp, "draco.rb"), "");
+
+    assertEquals(await resolveEntrypoint(tmp, "draco"), {
+      root: ".",
+      entrypoint: "draco.rb",
+    });
+  });
+
+  it("throws when nothing matches", async () => {
+    await assertRejects(
+      () => resolveEntrypoint(tmp, "mystery"),
+      Error,
+      "couldn't determine an entrypoint",
+    );
+  });
+});

--- a/utils/sources/resolve.ts
+++ b/utils/sources/resolve.ts
@@ -1,0 +1,101 @@
+import { exists } from "@std/fs";
+import { join } from "@std/path";
+import { parse } from "@std/toml";
+
+import type { PackageSpec } from "../manifest.ts";
+import { copyTree } from "../copy-tree.ts";
+
+export type VendorContext = {
+  /** Absolute path to the project's `mygame` directory. */
+  mygame: string;
+  /** Absolute directory the manifest lives in (resolves `path:` specs). */
+  manifestDir: string;
+  /** Progress logger. */
+  log: (message: string) => void;
+};
+
+/** Absolute path of a dependency's vendor directory. */
+export const vendorDir = (ctx: VendorContext, name: string): string =>
+  join(ctx.mygame, "vendor", name);
+
+/** A require path (relative to `mygame`) into a dependency's vendor directory. */
+export const vendorRequire = (name: string, entrypoint: string): string =>
+  `vendor/${name}/${entrypoint}`;
+
+/** Reads just the `[package]` table from a library's `drenv.toml`, if any. */
+const readPackage = async (dir: string): Promise<PackageSpec | undefined> => {
+  try {
+    const data = parse(await Deno.readTextFile(join(dir, "drenv.toml"))) as {
+      package?: PackageSpec;
+    };
+    return data.package;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Determines which directory of a fetched library is the package root and which
+ * file is its entrypoint:
+ *
+ *   1. an explicit override (consumer `-e` / manifest entrypoint), taken
+ *      relative to the fetched root;
+ *   2. the library's own `[package]` declaration (root + entrypoint);
+ *   3. convention — `lib/<name>.rb` (vendoring just `lib/`), then `<name>.rb`.
+ */
+export const resolveEntrypoint = async (
+  staging: string,
+  name: string,
+  override?: string,
+): Promise<{ root: string; entrypoint: string }> => {
+  if (override) return { root: ".", entrypoint: override };
+
+  const pkg = await readPackage(staging);
+  if (pkg?.entrypoint) {
+    return { root: pkg.root ?? ".", entrypoint: pkg.entrypoint };
+  }
+
+  if (await exists(join(staging, "lib", `${name}.rb`))) {
+    return { root: "lib", entrypoint: `${name}.rb` };
+  }
+  if (await exists(join(staging, `${name}.rb`))) {
+    return { root: ".", entrypoint: `${name}.rb` };
+  }
+
+  throw new Error(
+    `drenv: couldn't determine an entrypoint for '${name}' — the library declares no [package] entrypoint and neither lib/${name}.rb nor ${name}.rb exists; pass -e <file>`,
+  );
+};
+
+/**
+ * Mirrors a fetched library's package root into its vendor directory and
+ * returns the require path. `staging` is the fetched tree — a temp checkout for
+ * remote sources, or the source directory itself for path deps.
+ */
+export const stageIntoVendor = async (
+  staging: string,
+  ctx: VendorContext,
+  name: string,
+  override?: string,
+): Promise<string> => {
+  const { root, entrypoint } = await resolveEntrypoint(staging, name, override);
+
+  const source = root === "." ? staging : join(staging, root);
+  if (!await exists(source)) {
+    throw new Error(
+      `drenv: package root '${root}' not found in dependency '${name}'`,
+    );
+  }
+
+  const dest = vendorDir(ctx, name);
+  await Deno.remove(dest, { recursive: true }).catch(() => {});
+  await copyTree(source, dest);
+
+  if (!await exists(join(dest, entrypoint))) {
+    throw new Error(
+      `drenv: entrypoint '${entrypoint}' not found in dependency '${name}'`,
+    );
+  }
+
+  return vendorRequire(name, entrypoint);
+};

--- a/utils/sources/url.ts
+++ b/utils/sources/url.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join } from "@std/path";
 import type { DependencySpec } from "../manifest.ts";
 import type { LockedDependency } from "../lockfile.ts";
 import { treeDigest } from "../integrity.ts";
-import { type VendorContext, vendorDir, vendorRequire } from "./mod.ts";
+import { type VendorContext, vendorDir, vendorRequire } from "./resolve.ts";
 
 export const vendorUrl = async (
   spec: DependencySpec,


### PR DESCRIPTION
## Summary

Lets libraries define their own entrypoint, so consumers don't have to. With
this, adding a dependency is just:

```sh
drenv add github:Nitemaeric/conjuration
```

No `-e` needed — drenv figures out what to require, and vendors only the
library's code (not its `demo/`, `docs/`, etc.).

## How entrypoints resolve

When a dependency has no explicit entrypoint, drenv resolves one in order:

1. **Consumer override** — `-e` / a manifest `entrypoint` (taken relative to the
   fetched tree).
2. **The library's `[package]` declaration** — a library can describe itself in
   its own `drenv.toml`:
   ```toml
   [package]
   root = "lib"                  # only this dir is vendored (default ".")
   entrypoint = "conjuration.rb" # relative to root
   ```
3. **Convention** — `lib/<name>.rb` (vendoring just `lib/`), then `<name>.rb`.
4. Otherwise a clear error asking for `-e`.

conjuration already matches the convention, so it works with **zero changes to
the library**; the `[package]` table is there when a library wants explicit
control. This is also the mechanism a future transitive-deps feature would build
on.

## Notable changes

- Remote sources (`github`, `git`) now extract into a **staging dir** first, so
  only the resolved package `root` is mirrored into `vendor/<name>/`. Previously
  the whole repo was vendored.
- `drenv add` makes `-e` optional and **rolls the manifest back** if
  resolution/vendoring fails, so a bad add never leaves a half-written entry.
- Shared vendoring + resolution logic extracted to `utils/sources/resolve.ts`.

## Validation

- 17 tests pass — added `resolveEntrypoint` unit tests (override / `[package]` /
  convention / error) and a bundler integration test proving root-scoping
  (junk at the repo root is not vendored).
- Verified live against the real `github:Nitemaeric/conjuration`: minimal
  manifest (`github = "Nitemaeric/conjuration"`), lock
  `require = vendor/conjuration/conjuration.rb`, and only `lib/` vendored.
- `deno check` / `fmt` / `lint` / `compile` clean on the changed code.

## Release

`deno.json` is bumped to **0.8.1** in this branch. After merge, tag the tip of
`main` to publish the release:

```sh
git tag v0.8.1 && git push origin v0.8.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
