### PR TITLE
feat: watch path dependencies during `drenv run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,11 @@ directory.
 
 ### `drenv run [args...]`
 
-Syncs the current project's dependencies and launches it with DragonRuby. Any
-extra arguments are forwarded to the `dragonruby` binary.
+Syncs the current project's dependencies and launches it with DragonRuby. While
+the game runs, drenv watches any `path:` dependencies and re-vendors them as you
+edit, so changes hot-reload into the running game — handy when developing a
+library alongside it. Pass `--no-watch` to turn that off (`--frozen` skips it
+too). Extra arguments are forwarded to the `dragonruby` binary.
 
 ## Managing Dependencies
 

--- a/commands/run.ts
+++ b/commands/run.ts
@@ -4,17 +4,20 @@ import { join } from "@std/path";
 import { findProject } from "../utils/project.ts";
 import { reconcile } from "../utils/bundler.ts";
 import { BUNDLE_REQUIRE } from "../utils/bundle-file.ts";
+import { watchPathDeps } from "../utils/watch.ts";
 
 export default async function run(
   forwarded: string[] = [],
-  options: { frozen?: boolean } = {},
+  options: { frozen?: boolean; watch?: boolean } = {},
 ) {
   const project = await findProject();
+  const log = (message: string) => console.log(message);
+  const hasManifest = await exists(project.manifestPath);
 
   // Sync dependencies when this project declares any; otherwise just launch.
-  if (await exists(project.manifestPath)) {
+  if (hasManifest) {
     const { lock, needsRequireLine } = await reconcile(project, {
-      log: (message) => console.log(message),
+      log,
       frozen: options.frozen,
     });
 
@@ -34,13 +37,23 @@ export default async function run(
     throw new Error(`drenv: dragonruby binary not found at ${binary}`);
   }
 
-  const { code } = await new Deno.Command(binary, {
+  const child = new Deno.Command(binary, {
     args: ["mygame", ...forwarded],
     cwd: project.root,
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",
-  }).output();
+  }).spawn();
+
+  // Re-sync path dependencies as they change so edits hot-reload into the game.
+  const controller = new AbortController();
+  const watching = hasManifest && options.watch !== false && !options.frozen
+    ? watchPathDeps(project, controller.signal, log)
+    : Promise.resolve();
+
+  const { code } = await child.status;
+  controller.abort();
+  await watching.catch(() => {});
 
   if (code !== 0) {
     Deno.exit(code);

--- a/main.ts
+++ b/main.ts
@@ -95,6 +95,7 @@ program
   .command("run")
   .argument("[args...]", "Arguments forwarded to the dragonruby binary")
   .option("--frozen", "Verify against the lockfile instead of updating it")
+  .option("--no-watch", "Don't re-sync path dependencies as they change")
   .allowUnknownOption()
   .description("Sync dependencies and launch the project with DragonRuby")
   .action(actionRunner(run, { skipUpdateCheck: true }));

--- a/utils/watch.test.ts
+++ b/utils/watch.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assert } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+import { bundle } from "./bundler.ts";
+import { watchPathDeps } from "./watch.ts";
+import type { Project } from "./project.ts";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Polls `read` until it returns `expected`, up to `timeoutMs`. */
+const waitFor = async (
+  read: () => Promise<string>,
+  expected: string,
+  timeoutMs = 8000,
+): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if ((await read()) === expected) return true;
+    } catch {
+      // file mid-write — retry
+    }
+    await delay(50);
+  }
+  return false;
+};
+
+describe("watchPathDeps", () => {
+  let tmp: string;
+  let project: Project;
+  let controller: AbortController;
+  let watching: Promise<void>;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "drenv-watch-" });
+
+    await ensureDir(join(tmp, "lib", "conjuration"));
+    await Deno.writeTextFile(
+      join(tmp, "lib", "conjuration.rb"),
+      'require_relative "conjuration/node"\n',
+    );
+    await Deno.writeTextFile(
+      join(tmp, "lib", "conjuration", "node.rb"),
+      "class Node; end\n",
+    );
+
+    const mygame = join(tmp, "game", "mygame");
+    await ensureDir(join(mygame, "app"));
+    await Deno.writeTextFile(
+      join(mygame, "drenv.toml"),
+      '[dependencies.conjuration]\npath = "../../lib"\nentrypoint = "conjuration.rb"\n',
+    );
+    await Deno.writeTextFile(
+      join(mygame, "app", "main.rb"),
+      "def tick args\nend\n",
+    );
+
+    project = {
+      root: join(tmp, "game"),
+      mygame,
+      manifestPath: join(mygame, "drenv.toml"),
+      lockPath: join(mygame, "drenv.lock"),
+    };
+
+    await bundle(project);
+  });
+
+  afterEach(async () => {
+    controller?.abort();
+    await watching?.catch(() => {});
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("re-vendors a path dep when its source changes", async () => {
+    const vendored = join(
+      project.mygame,
+      "vendor",
+      "conjuration",
+      "conjuration",
+      "node.rb",
+    );
+
+    controller = new AbortController();
+    watching = watchPathDeps(project, controller.signal, () => {});
+    await delay(400); // let the watcher start before editing
+
+    await Deno.writeTextFile(
+      join(tmp, "lib", "conjuration", "node.rb"),
+      "class Node; def x; end; end\n",
+    );
+
+    const synced = await waitFor(
+      () => Deno.readTextFile(vendored),
+      "class Node; def x; end; end\n",
+    );
+    assert(
+      synced,
+      "vendored file should be re-synced after the source changed",
+    );
+  });
+});

--- a/utils/watch.ts
+++ b/utils/watch.ts
@@ -45,7 +45,9 @@ export const watchPathDeps = async (
 
   const watcher = Deno.watchFs(targets.map((t) => t.dir));
   const pending = new Set<string>();
-  let timer: number | undefined;
+  // `ReturnType<typeof setTimeout>` rather than `number`: newer Deno types the
+  // timer id as `Timeout`.
+  let timer: ReturnType<typeof setTimeout> | undefined;
   let flushing: Promise<void> = Promise.resolve();
 
   const stop = () => {

--- a/utils/watch.ts
+++ b/utils/watch.ts
@@ -1,0 +1,107 @@
+import { exists } from "@std/fs";
+import { dirname, resolve, SEPARATOR } from "@std/path";
+
+import { readManifest, sourceKind } from "./manifest.ts";
+import { type VendorContext, vendorDependency } from "./sources/mod.ts";
+import type { Project } from "./project.ts";
+
+const DEBOUNCE_MS = 150;
+
+const ignored = (path: string): boolean =>
+  path.endsWith(".DS_Store") || path.includes(`${SEPARATOR}.git${SEPARATOR}`);
+
+/**
+ * Watches the source directory of every `path:` dependency and re-vendors it
+ * when its files change, so DragonRuby's hot reload picks up edits to a local
+ * library while the game runs. Remote deps are pinned, so they're never
+ * watched. Runs until `signal` is aborted (when the game exits).
+ */
+export const watchPathDeps = async (
+  project: Project,
+  signal: AbortSignal,
+  log: (message: string) => void,
+): Promise<void> => {
+  const manifest = await readManifest(project.manifestPath);
+  const manifestDir = dirname(project.manifestPath);
+
+  const targets: { name: string; dir: string }[] = [];
+  for (const dep of manifest.dependencies) {
+    if (sourceKind(dep) !== "path") continue;
+    const dir = resolve(manifestDir, dep.path!);
+    if (!await exists(dir)) continue;
+    // Canonicalize so prefix checks match the paths fs events report — macOS
+    // reports /private/var/… for a /var/… symlink, for example.
+    targets.push({ name: dep.name, dir: await Deno.realPath(dir) });
+  }
+  if (targets.length === 0) return;
+
+  // Re-vendor quietly; we print our own concise "re-synced" lines instead.
+  const ctx: VendorContext = {
+    mygame: project.mygame,
+    manifestDir,
+    log: () => {},
+  };
+  const specs = new Map(manifest.dependencies.map((dep) => [dep.name, dep]));
+
+  const watcher = Deno.watchFs(targets.map((t) => t.dir));
+  const pending = new Set<string>();
+  let timer: number | undefined;
+  let flushing: Promise<void> = Promise.resolve();
+
+  const stop = () => {
+    if (timer !== undefined) clearTimeout(timer);
+    try {
+      watcher.close();
+    } catch {
+      // already closed
+    }
+  };
+  if (signal.aborted) return stop();
+  signal.addEventListener("abort", stop, { once: true });
+
+  const flush = async () => {
+    for (const name of [...pending]) {
+      pending.delete(name);
+      const spec = specs.get(name);
+      if (!spec) continue;
+      try {
+        await vendorDependency(spec, ctx);
+        log(`drenv: re-synced ${name}`);
+      } catch (error) {
+        log(`drenv: failed to re-sync ${name} — ${(error as Error).message}`);
+      }
+    }
+  };
+
+  log(
+    `drenv: watching ${targets.length} path ${
+      targets.length === 1 ? "dependency" : "dependencies"
+    } for changes`,
+  );
+
+  try {
+    for await (const event of watcher) {
+      if (event.kind === "access") continue;
+
+      for (const target of targets) {
+        const touched = event.paths.some((path) =>
+          !ignored(path) &&
+          (path === target.dir || path.startsWith(target.dir + SEPARATOR))
+        );
+        if (touched) pending.add(target.name);
+      }
+
+      if (pending.size > 0) {
+        if (timer !== undefined) clearTimeout(timer);
+        timer = setTimeout(() => {
+          flushing = flushing.then(flush);
+        }, DEBOUNCE_MS);
+      }
+    }
+  } catch {
+    // watcher closed on shutdown — nothing more to do
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    await flushing;
+  }
+};


### PR DESCRIPTION
## Summary

While `drenv run`'s game is running, drenv now watches each `path:` dependency's
source directory and re-vendors it on change, so edits to a local library
hot-reload straight into the running game — automating the manual sync the demo
did via `bin/sync-demo-lib.sh`.

Only `path:` deps are watched (github/git/url are pinned). On by default;
disabled by `--no-watch` or `--frozen`.

## How it works

`run` spawns the game, then watches the path deps' source dirs with
`Deno.watchFs` (debounced). On a change it re-vendors the affected dep into
`mygame/vendor/`, which DragonRuby's hot reload picks up. The watcher is aborted
cleanly when the game exits.

## Verification

- Added a real `Deno.watchFs` integration test (edit a source file → vendored
  copy updates). It caught a macOS quirk — fs events report canonical
  `/private/var/…` paths — fixed by canonicalizing watched dirs with
  `Deno.realPath`.
- End-to-end CLI smoke test with a fake `dragonruby`: `run` logged
  `watching 1 path dependency`, an edit mid-run logged `re-synced conjuration`,
  and the vendored file reflected the edit before a clean exit.
- 18 tests; `check` / `fmt` / `lint` / `compile` clean.

No version bump here — set it at release time (`deno task release <X.Y.Z>` from
`main` after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
