### PR TITLE
feat: add `--version` flag to `drenv new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Lists all registered versions, with the current local version marked:
 
 ### `drenv new <name>`
 
-Creates a new DragonRuby project by copying the global version into a new
-directory.
+Creates a new DragonRuby project by copying a registered version into a new
+directory. Uses the global version by default; pass `--version <version>` to
+pick a specific one.
 
 ### `drenv update [version]`
 

--- a/commands/new.test.ts
+++ b/commands/new.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { assert, assertRejects } from "@std/assert";
+import { ensureDir, exists } from "@std/fs";
+import { join } from "@std/path";
+
+import newCommand, { NotInstalled } from "./new.ts";
+import { versionsPath } from "../constants.ts";
+
+describe("new", () => {
+  beforeAll(async () => {
+    await ensureDir(`${versionsPath}/99.99`);
+    await Deno.writeTextFile(`${versionsPath}/99.99/marker.txt`, "v99.99");
+  });
+
+  afterAll(async () => {
+    await Deno.remove(`${versionsPath}/99.99`, { recursive: true });
+  });
+
+  describe("with --version", () => {
+    it("creates the project from the given version", async () => {
+      const tmp = await Deno.makeTempDir({ prefix: "drenv-new-" });
+      const dest = join(tmp, "proj");
+
+      await newCommand(dest, { version: "99.99" });
+
+      assert(await exists(join(dest, "marker.txt")));
+      await Deno.remove(tmp, { recursive: true });
+    });
+
+    it("rejects when the version isn't installed", async () => {
+      const tmp = await Deno.makeTempDir({ prefix: "drenv-new-" });
+
+      await assertRejects(
+        () => newCommand(join(tmp, "proj"), { version: "0.0.0" }),
+        NotInstalled,
+        "version '0.0.0' not installed",
+      );
+
+      await Deno.remove(tmp, { recursive: true });
+    });
+  });
+});

--- a/commands/new.ts
+++ b/commands/new.ts
@@ -1,9 +1,30 @@
-import { copy } from "@std/fs";
+import { copy, exists } from "@std/fs";
 
 import { versionsPath } from "../constants.ts";
 
 import global from "./global.ts";
 
-export default async function newCommand(name: string) {
+export class NotInstalled extends Error {
+  version: string;
+
+  constructor(version: string) {
+    super(`drenv: version '${version}' not installed`);
+
+    this.name = "NotInstalled";
+    this.version = version;
+  }
+}
+
+export default async function newCommand(
+  name: string,
+  options: { version?: string } = {},
+) {
+  if (options.version) {
+    if (!await exists(`${versionsPath}/${options.version}`)) {
+      throw new NotInstalled(options.version);
+    }
+    return copy(`${versionsPath}/${options.version}`, name);
+  }
+
   return copy(`${versionsPath}/${await global()}`, name);
 }

--- a/main.ts
+++ b/main.ts
@@ -63,7 +63,10 @@ const actionRunner = (
 program
   .name("drenv")
   .description("CLI to manage DragonRuby environments")
-  .version(config.version);
+  .version(config.version)
+  // Restrict the program's `--version` to before a subcommand, so `new` can
+  // accept its own `--version <version>` option.
+  .enablePositionalOptions();
 
 program
   .command("setup")
@@ -73,6 +76,10 @@ program
 program
   .command("new")
   .argument("<name>", "Name of the new project")
+  .option(
+    "--version <version>",
+    "DragonRuby version to use (defaults to the global version)",
+  )
   .description("Create a new DragonRuby project")
   .action(actionRunner(newCommand));
 


### PR DESCRIPTION
## Summary

`drenv new <name> --version <version>` creates the project from a specific
registered version instead of the global one:

```sh
drenv new my-game --version 6.4
```

Without `--version`, behavior is unchanged (uses the global version). An
uninstalled version errors clearly: `version '6.4' not installed`.

## Note

The subcommand's `--version` collided with commander's program-level
`--version` (it was printing drenv's own version). Fixed with
`enablePositionalOptions()`, with the rest of the option surface verified intact
(`drenv --version`, `run --frozen`, and flag forwarding).

## Verification

18 tests (added `new.test.ts`); `check` / `fmt` / `lint` / `compile` clean.

No version bump here — set it at release time (`deno task release <X.Y.Z>` from
`main` after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
