### PR TITLE
feat: default `drenv update` to latest + add `--version` and confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ Creates a new DragonRuby project by copying a registered version into a new
 directory. Uses the global version by default; pass `--version <version>` to
 pick a specific one.
 
-### `drenv update [version]`
+### `drenv update`
 
-Updates the current directory's DragonRuby version, preserving the `mygame`
-directory.
+Updates the current project to a registered DragonRuby version, preserving the
+`mygame` directory. Defaults to the latest installed version; pass
+`--version <version>` for a specific one. Asks for confirmation first.
 
 ### `drenv run [args...]`
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Lists all registered versions, with the current local version marked:
 
 ### `drenv new <name>`
 
-Creates a new DragonRuby project by copying the global version into a new
-directory.
+Creates a new DragonRuby project by copying a registered version into a new
+directory. Uses the global version by default; pass `--version <version>` to
+pick a specific one.
 
 ### `drenv update [version]`
 

--- a/commands/new.test.ts
+++ b/commands/new.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { assert, assertRejects } from "@std/assert";
+import { ensureDir, exists } from "@std/fs";
+import { join } from "@std/path";
+
+import newCommand, { NotInstalled } from "./new.ts";
+import { versionsPath } from "../constants.ts";
+
+describe("new", () => {
+  beforeAll(async () => {
+    await ensureDir(`${versionsPath}/99.99`);
+    await Deno.writeTextFile(`${versionsPath}/99.99/marker.txt`, "v99.99");
+  });
+
+  afterAll(async () => {
+    await Deno.remove(`${versionsPath}/99.99`, { recursive: true });
+  });
+
+  describe("with --version", () => {
+    it("creates the project from the given version", async () => {
+      const tmp = await Deno.makeTempDir({ prefix: "drenv-new-" });
+      const dest = join(tmp, "proj");
+
+      await newCommand(dest, { version: "99.99" });
+
+      assert(await exists(join(dest, "marker.txt")));
+      await Deno.remove(tmp, { recursive: true });
+    });
+
+    it("rejects when the version isn't installed", async () => {
+      const tmp = await Deno.makeTempDir({ prefix: "drenv-new-" });
+
+      await assertRejects(
+        () => newCommand(join(tmp, "proj"), { version: "0.0.0" }),
+        NotInstalled,
+        "version '0.0.0' not installed",
+      );
+
+      await Deno.remove(tmp, { recursive: true });
+    });
+  });
+});

--- a/commands/new.ts
+++ b/commands/new.ts
@@ -1,9 +1,30 @@
-import { copy } from "@std/fs";
+import { copy, exists } from "@std/fs";
 
 import { versionsPath } from "../constants.ts";
 
 import global from "./global.ts";
 
-export default async function newCommand(name: string) {
+export class NotInstalled extends Error {
+  version: string;
+
+  constructor(version: string) {
+    super(`drenv: version '${version}' not installed`);
+
+    this.name = "NotInstalled";
+    this.version = version;
+  }
+}
+
+export default async function newCommand(
+  name: string,
+  options: { version?: string } = {},
+) {
+  if (options.version) {
+    if (!await exists(`${versionsPath}/${options.version}`)) {
+      throw new NotInstalled(options.version);
+    }
+    return copy(`${versionsPath}/${options.version}`, name);
+  }
+
   return copy(`${versionsPath}/${await global()}`, name);
 }

--- a/commands/update.test.ts
+++ b/commands/update.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { ensureDir, exists } from "@std/fs";
+
+import update, { NotInstalled } from "./update.ts";
+import { versionsPath } from "../constants.ts";
+
+describe("update", () => {
+  let cwd: string;
+  let tmp: string;
+  let realPrompt: typeof globalThis.prompt;
+
+  beforeEach(async () => {
+    cwd = Deno.cwd();
+    tmp = await Deno.makeTempDir({ prefix: "drenv-update-" });
+    Deno.chdir(tmp);
+    realPrompt = globalThis.prompt;
+
+    // Use high versions so these fixtures are reliably the "latest" installed.
+    await ensureDir(`${versionsPath}/97.01`);
+    await Deno.writeTextFile(
+      `${versionsPath}/97.01/CHANGELOG-CURR.txt`,
+      "* 97.01",
+    );
+    await ensureDir(`${versionsPath}/97.02`);
+    await Deno.writeTextFile(
+      `${versionsPath}/97.02/CHANGELOG-CURR.txt`,
+      "* 97.02",
+    );
+  });
+
+  afterEach(async () => {
+    globalThis.prompt = realPrompt;
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+    await Deno.remove(`${versionsPath}/97.01`, { recursive: true });
+    await Deno.remove(`${versionsPath}/97.02`, { recursive: true });
+  });
+
+  it("updates to the latest installed version by default", async () => {
+    globalThis.prompt = () => "";
+
+    await update();
+
+    assertEquals(await Deno.readTextFile("./CHANGELOG-CURR.txt"), "* 97.02");
+  });
+
+  it("updates to a specific version with --version", async () => {
+    globalThis.prompt = () => "";
+
+    await update({ version: "97.01" });
+
+    assertEquals(await Deno.readTextFile("./CHANGELOG-CURR.txt"), "* 97.01");
+  });
+
+  it("cancels when the user answers no", async () => {
+    globalThis.prompt = () => "n";
+
+    const result = await update({ version: "97.01" });
+
+    assertEquals(result, "drenv: update cancelled");
+    assert(!await exists("./CHANGELOG-CURR.txt"));
+  });
+
+  it("rejects an uninstalled version", async () => {
+    globalThis.prompt = () => "";
+
+    await assertRejects(
+      () => update({ version: "0.0" }),
+      NotInstalled,
+      "version '0.0' not installed",
+    );
+  });
+});

--- a/commands/update.ts
+++ b/commands/update.ts
@@ -1,7 +1,7 @@
 import { copy, exists } from "@std/fs";
 
-import { readVersion } from "../utils/read-version.ts";
 import { versionsPath } from "../constants.ts";
+import { latestInstalledVersion } from "../utils/installed-versions.ts";
 
 export class NotInstalled extends Error {
   version: string;
@@ -14,34 +14,39 @@ export class NotInstalled extends Error {
   }
 }
 
-export default function local(version: string | undefined = undefined) {
-  if (version) {
-    return setLocalVersion(version);
-  } else {
-    return getLocalVersion();
+export class NoVersionsInstalled extends Error {
+  constructor() {
+    super("drenv: no versions installed — run `drenv install` first");
+    this.name = "NoVersionsInstalled";
   }
 }
 
-const setLocalVersion = async (version: string) => {
-  const sourceDirectory = `${versionsPath}/${version}`;
+export default async function update(options: { version?: string } = {}) {
+  const version = options.version ?? await latestInstalledVersion();
 
-  if (!await exists(sourceDirectory)) {
+  if (!version) {
+    throw new NoVersionsInstalled();
+  }
+
+  if (!await exists(`${versionsPath}/${version}`)) {
     throw new NotInstalled(version);
   }
 
-  const items = Deno.readDir(sourceDirectory);
-
-  for await (const item of items) {
-    if (item.name == "mygame") {
-      continue;
-    }
-
-    await copy(sourceDirectory + "/" + item.name, "./" + item.name, {
-      overwrite: true,
-    });
+  const answer = prompt(`drenv: Update to version ${version}? Y/n (Y)`) ?? "";
+  if (answer.trim().toLowerCase().startsWith("n")) {
+    return "drenv: update cancelled";
   }
-};
 
-const getLocalVersion = () => {
-  return readVersion("./CHANGELOG-CURR.txt");
-};
+  // Copy the version's files over the current directory, preserving the game.
+  for await (const item of Deno.readDir(`${versionsPath}/${version}`)) {
+    if (item.name === "mygame") continue;
+
+    await copy(
+      `${versionsPath}/${version}/${item.name}`,
+      `./${item.name}`,
+      { overwrite: true },
+    );
+  }
+
+  return `drenv: Updated to version ${version}`;
+}

--- a/main.ts
+++ b/main.ts
@@ -149,8 +149,11 @@ program
 
 program
   .command("update")
-  .argument("[version]", "Version of DragonRuby to use")
-  .description("Get or set the local version of DragonRuby")
+  .option(
+    "--version <version>",
+    "DragonRuby version to update to (defaults to the latest installed)",
+  )
+  .description("Update the current project to a DragonRuby version")
   .action(actionRunner(update));
 
 program

--- a/main.ts
+++ b/main.ts
@@ -63,7 +63,10 @@ const actionRunner = (
 program
   .name("drenv")
   .description("CLI to manage DragonRuby environments")
-  .version(config.version);
+  .version(config.version)
+  // Restrict the program's `--version` to before a subcommand, so `new` can
+  // accept its own `--version <version>` option.
+  .enablePositionalOptions();
 
 program
   .command("setup")
@@ -73,6 +76,10 @@ program
 program
   .command("new")
   .argument("<name>", "Name of the new project")
+  .option(
+    "--version <version>",
+    "DragonRuby version to use (defaults to the global version)",
+  )
   .description("Create a new DragonRuby project")
   .action(actionRunner(newCommand));
 

--- a/utils/installed-versions.ts
+++ b/utils/installed-versions.ts
@@ -1,0 +1,35 @@
+import { versionsPath } from "../constants.ts";
+
+/** Compares DragonRuby `major.minor` versions numerically. */
+export const compareVersions = (first: string, second: string): number => {
+  const [firstMajor, firstMinor] = first.split(".").map(Number);
+  const [secondMajor, secondMinor] = second.split(".").map(Number);
+
+  if (firstMajor === secondMajor) {
+    return firstMinor - secondMinor;
+  }
+  return firstMajor - secondMajor;
+};
+
+/** Installed version names, newest first. */
+export const installedVersions = async (): Promise<string[]> => {
+  let entries: Deno.DirEntry[] = [];
+
+  try {
+    entries = await Array.fromAsync(Deno.readDir(versionsPath));
+  } catch {
+    // No versions installed yet.
+  }
+
+  return entries
+    .filter((entry) => entry.isDirectory)
+    .map((entry) => entry.name)
+    .toSorted((first, second) => compareVersions(second, first));
+};
+
+/** The newest installed version, or undefined when none are installed. */
+export const latestInstalledVersion = async (): Promise<
+  string | undefined
+> => {
+  return (await installedVersions())[0];
+};


### PR DESCRIPTION
## Summary

Reworks `drenv update` to mirror `drenv new`'s `--version` flag and add a
confirmation step:

- **Defaults to the latest installed version** (was: a no-arg call printed the
  current local version).
- **`--version <version>`** updates to a specific registered version.
- **Always confirms first** — `drenv: Update to version x.xx? Y/n (Y)` (default
  Y) — before overwriting project files. `mygame/` is preserved as before.

The old "print the local version" behavior is dropped; `drenv versions` already
shows the current version (marked with `*`).

## ⚠️ Stacked on #22

`update --version` reuses the `enablePositionalOptions()` fix from #22 (otherwise
the program-level `--version` intercepts it). This PR is **based on
`feat/new-version-flag`** and will auto-retarget to `main` once #22 merges — so
**merge #22 first**.

## Notes

- The confirmation uses Deno's `prompt()`, which is interactive: in a terminal
  it asks; piped/non-interactive runs proceed with the default (Y), since
  there's no TTY to read from.
- Replaced the positional `[version]` argument with `--version`, matching `new`.

## Verification

19 tests (added `update.test.ts` — latest-default, `--version`, cancel-on-no,
and uninstalled-version); `check` / `fmt` / `lint` / `compile` clean under Deno
2.9.0. `drenv update --version 0.0` → `version '0.0' not installed` (not the
program version), and `drenv --version` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
