### PR TITLE
feat: scaffold a project .gitignore in `drenv new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ Lists all registered versions, with the current local version marked:
 ### `drenv new <name>`
 
 Creates a new DragonRuby project by copying a registered version into a new
-directory. Uses the global version by default; pass `--version <version>` to
-pick a specific one.
+directory, and writes a project `.gitignore` (covering the DragonRuby binaries,
+`builds/`, `tmp/`, `logs/`, docs, and samples). Uses the global version by
+default; pass `--version <version>` for a specific one, or `--skip-gitignore` to
+skip writing the `.gitignore`.
 
 ### `drenv update`
 

--- a/commands/new.test.ts
+++ b/commands/new.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
-import { assert, assertRejects } from "@std/assert";
+import { assert, assertRejects, assertStringIncludes } from "@std/assert";
 import { ensureDir, exists } from "@std/fs";
 import { join } from "@std/path";
 
@@ -36,6 +36,31 @@ describe("new", () => {
         "version '0.0.0' not installed",
       );
 
+      await Deno.remove(tmp, { recursive: true });
+    });
+  });
+
+  describe(".gitignore", () => {
+    it("generates a project .gitignore by default", async () => {
+      const tmp = await Deno.makeTempDir({ prefix: "drenv-new-" });
+      const dest = join(tmp, "proj");
+
+      await newCommand(dest, { version: "99.99" });
+
+      const gitignore = await Deno.readTextFile(join(dest, ".gitignore"));
+      assertStringIncludes(gitignore, "dragonruby");
+      assertStringIncludes(gitignore, "tmp/");
+
+      await Deno.remove(tmp, { recursive: true });
+    });
+
+    it("skips it with --skip-gitignore", async () => {
+      const tmp = await Deno.makeTempDir({ prefix: "drenv-new-" });
+      const dest = join(tmp, "proj");
+
+      await newCommand(dest, { version: "99.99", skipGitignore: true });
+
+      assert(!await exists(join(dest, ".gitignore")));
       await Deno.remove(tmp, { recursive: true });
     });
   });

--- a/commands/new.ts
+++ b/commands/new.ts
@@ -15,16 +15,45 @@ export class NotInstalled extends Error {
   }
 }
 
+const PROJECT_GITIGNORE = `.DS_Store
+
+# DragonRuby binaries (re-added by drenv new / drenv update)
+dragonruby
+dragonruby.exe
+dragonruby-publish
+dragonruby-publish.exe
+dragonruby-bind
+dragonruby-bind.exe
+dragonruby-firestarter
+dragonruby-httpd
+
+# Build and runtime artifacts
+builds/
+logs/
+tmp/
+.dragonruby/
+
+# Bundled DragonRuby docs and samples
+docs/
+samples/
+`;
+
+type NewOptions = { version?: string; skipGitignore?: boolean };
+
 export default async function newCommand(
   name: string,
-  options: { version?: string } = {},
+  options: NewOptions = {},
 ) {
   if (options.version) {
     if (!await exists(`${versionsPath}/${options.version}`)) {
       throw new NotInstalled(options.version);
     }
-    return copy(`${versionsPath}/${options.version}`, name);
+    await copy(`${versionsPath}/${options.version}`, name);
+  } else {
+    await copy(`${versionsPath}/${await global()}`, name);
   }
 
-  return copy(`${versionsPath}/${await global()}`, name);
+  if (!options.skipGitignore) {
+    await Deno.writeTextFile(`${name}/.gitignore`, PROJECT_GITIGNORE);
+  }
 }

--- a/main.ts
+++ b/main.ts
@@ -80,6 +80,7 @@ program
     "--version <version>",
     "DragonRuby version to use (defaults to the global version)",
   )
+  .option("--skip-gitignore", "Don't generate a .gitignore in the new project")
   .description("Create a new DragonRuby project")
   .action(actionRunner(newCommand));
 


### PR DESCRIPTION
## Summary

`drenv new` now scaffolds a project `.gitignore` so a freshly-created project is
commit-ready. Since `new` copies the *entire* DragonRuby install, the working
tree otherwise includes the multi-MB `dragonruby` binary, `docs/`, `samples/`,
and runtime dirs — which you don't want in a game's repo.

The generated `.gitignore` covers:

- DragonRuby binaries — `dragonruby`, `dragonruby-publish`, `dragonruby-bind`,
  `dragonruby-firestarter`, `dragonruby-httpd` (+ `.exe`)
- Build / runtime dirs — `builds/`, `logs/`, `tmp/`, `.dragonruby/`
- Bundled `docs/` and `samples/`
- `.DS_Store`

This complements the `mygame/vendor/.gitignore` that vendoring already writes
(v0.8.2) — different scopes, no overlap.

## Flag

`drenv new <name> --skip-gitignore` skips writing the `.gitignore`.

## Verification

20 tests (added coverage that `new` writes the `.gitignore` by default and skips
it with `--skip-gitignore`); `check` / `fmt` / `lint` / `compile` clean under
Deno 2.9.0. Verified via the CLI that `drenv new … --version <v>` writes the
file and `--skip-gitignore` omits it.

No version bump in this branch — set it at release time (`deno task release
<X.Y.Z>` from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
