### PR TITLE
refactor: split help groups and guard releases to main

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -92,6 +92,17 @@ jobs:
     needs:
       - build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify the tag is on main
+        run: |
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at a commit that is not on main — refusing to publish a release."
+            exit 1
+          fi
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/main.ts
+++ b/main.ts
@@ -61,6 +61,7 @@ const actionRunner = (
 
 // Help groupings shown as headings in `drenv --help`.
 const ENGINE = "Engine management:";
+const PROJECT = "Project management:";
 const DEPENDENCIES = "Dependency management:";
 const DRENV = "Managing drenv:";
 
@@ -120,6 +121,8 @@ program
   .helpGroup(ENGINE)
   .action(actionRunner(changelog));
 
+// --- Project management ------------------------------------------------------
+
 program
   .command("new")
   .argument("<name>", "Name of the new project")
@@ -129,7 +132,7 @@ program
   )
   .option("--skip-gitignore", "Don't generate a .gitignore in the new project")
   .description("Create a new DragonRuby project")
-  .helpGroup(ENGINE)
+  .helpGroup(PROJECT)
   .action(actionRunner(newCommand));
 
 program
@@ -139,7 +142,7 @@ program
     "Version to switch the project to (defaults to the latest installed)",
   )
   .description("Switch the current project to a DragonRuby version")
-  .helpGroup(ENGINE)
+  .helpGroup(PROJECT)
   .action(actionRunner(use));
 
 program
@@ -149,7 +152,7 @@ program
   .option("--no-watch", "Don't re-sync path dependencies as they change")
   .allowUnknownOption()
   .description("Sync dependencies and launch the project with DragonRuby")
-  .helpGroup(ENGINE)
+  .helpGroup(PROJECT)
   .action(actionRunner(run, { skipUpdateCheck: true }));
 
 program
@@ -159,7 +162,7 @@ program
   .description(
     "Verify dependencies against the lockfile, then publish with dragonruby-publish",
   )
-  .helpGroup(ENGINE)
+  .helpGroup(PROJECT)
   .action(actionRunner(publish, { skipUpdateCheck: true }));
 
 // --- Dependency management --------------------------------------------------


### PR DESCRIPTION
## Help grouping

Splits the old **Engine management** group, which conflated two concerns, into:

- **Version management** — install, register, versions, global, changelog, new, use
- **Building & running** — run, publish (the build-time dependency-injection consumers)

**Dependency management** (add, remove, bundle) and **Managing drenv** (self-update) are unchanged. Four groups total.

## Release guard

The `release` workflow job now checks that the tagged commit is reachable from `main` (`git merge-base --is-ancestor`) before publishing. A tag pushed off a feature branch can no longer cut a release. `scripts/release.ts` already refuses to run off `main`; this closes the workflow-side gap.

No command behavior changes — grouping is help-text only. Patch release (0.10.1).