### PR TITLE
docs: simplify README for onboarding, move reference to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# drenv - DragonRuby Environment Manager
+# drenv
 
-**drenv** is a cross-platform CLI tool that helps you declutter your DragonRuby
-installations.
+**drenv** manages your DragonRuby installs and your game's dependencies — think
+[rbenv](https://rbenv.org) and Bundler, for
+[DragonRuby](https://dragonruby.org).
 
-**drenv** is built with [Deno](https://deno.com) and is inspired by
-[rbenv](https://rbenv.org).
+- Install and switch between DragonRuby versions — standard, indie, and pro,
+  side by side.
+- Scaffold new projects and pin each one to a version.
+- Vendor Ruby dependencies into your game, reproducibly.
 
-## Installation
-
-Install the latest release with the install script, which downloads the right
-binary for your platform, drops it in `~/.drenv/bin`, and prints the line to add
-to your `$PATH`:
+## Install
 
 ```sh
 # macOS / Linux
@@ -22,222 +21,100 @@ curl -fsSL drenv.org/install.sh | bash
 irm https://drenv.org/install.ps1 | iex
 ```
 
-Prefer to do it by hand? Download the executable for your platform from the
+The script drops the binary in `~/.drenv/bin` and prints the line to add to your
+`$PATH`. Update any time with `drenv self-update`.
+
+<details>
+<summary>Manual install / macOS Gatekeeper</summary>
+
+Download a binary from the
 [releases page](https://github.com/Nitemaeric/drenv/releases), move it to
-`~/.drenv/bin`, and add that directory to your `$PATH`.
+`~/.drenv/bin`, and add that directory to your `$PATH`. On macOS, clear the
+quarantine flag if you're warned:
+
+```sh
+xattr -d com.apple.quarantine ./drenv
+```
+
+</details>
+
+## Quick start
+
+```sh
+drenv install        # download DragonRuby (asks which tier you own)
+drenv new my-game    # scaffold a project on that version
+cd my-game
+drenv run            # launch it
+```
+
+Your first install becomes the global default, so `new` just works. Have more
+than one version or tier? They live side by side — `drenv versions` lists them,
+`drenv global <version>` sets the default, and `drenv use <version>` switches
+the current project. See [Managing versions](docs/versions.md) for tiers and
+version resolution.
 
 > [!NOTE]
-> On macOS, if you see a Gatekeeper warning, run:
->
-> ```sh
-> xattr -d com.apple.quarantine ./drenv
-> ```
+> `drenv install` needs a DragonRuby purchase — [itch.io](https://itch.io) for
+> standard, a [dragonruby.org](https://dragonruby.org) subscription for
+> indie/pro.
 
-> [!NOTE]
-> Once installed, keep **drenv** up to date by running `drenv self-update`.
+## Dependencies
 
-Alternatively, you can build from source:
+drenv vendors Ruby libraries into your game, Bundler-style. Add one:
 
 ```sh
-deno compile -A --unstable-kv --output=builds/drenv --target=aarch64-apple-darwin main.ts
+drenv add github:Nitemaeric/conjuration
 ```
 
-## Getting Started
-
-### 1. Install DragonRuby
-
-```sh
-drenv install
-```
-
-drenv asks which tier you own (standard, indie, or pro) and remembers it, then
-downloads the latest DragonRuby GTK. Standard comes from your
-[itch.io](https://itch.io) account (stored as a revocable API key, never a
-plaintext password); indie and pro come from
-[dragonruby.org](https://dragonruby.org) via your account email and password.
-
-> [!NOTE]
-> `drenv install` requires a DragonRuby GTK purchase — itch.io for standard, a
-> dragonruby.org subscription for indie/pro.
-
-### 2. Set a global version
-
-```sh
-drenv global <version>
-```
-
-### 3. Create a project
-
-```sh
-drenv new my-game
-```
-
----
-
-## Managing DragonRuby Versions
-
-### `drenv install`
-
-Downloads and installs the latest DragonRuby GTK. Prompts for your tier the
-first time and remembers it; pass `--tier standard|indie|pro` to choose or
-switch. Standard downloads from itch.io, indie and pro from dragonruby.org.
-
-Tiers are installed side by side. Each version+tier gets its own directory —
-standard keeps the bare version (`7.11`), while indie and pro are suffixed
-(`7.11-pro`, `7.11-indie`) — so installing pro doesn't clobber your standard
-copy of the same version.
-
-### `drenv register <path>`
-
-Registers a local DragonRuby installation manually. The path can be a `.zip`
-file or a directory containing the `dragonruby` executable. Useful if you
-already have a copy downloaded. Pass `--tier indie|pro` to file it under that
-tier (defaults to `standard`).
-
-### `drenv global [version]`
-
-Sets the global DragonRuby version used when creating new projects. Running
-without arguments prints the current global version.
-
-A bare version resolves to the highest tier you have installed. So `7.11` picks
-`7.11-pro` if present, then `7.11-indie`, then `7.11` (standard). To pin a tier,
-name it — `7.11-pro`, or `7.11-standard` for the standard build. The same
-resolution applies anywhere a version is accepted (`new --version`, `use`), and
-`drenv use` with no version switches to your highest installed tier.
-
-### `drenv versions`
-
-Lists all registered versions, with the current local version marked and each
-tier labelled:
-
-```
-  7.11 Pro
-* 6.4
-  5.32
-```
-
-## Managing DragonRuby Projects
-
-### `drenv new <name>`
-
-Creates a new DragonRuby project by copying a registered version into a new
-directory, and writes a project `.gitignore` (covering the DragonRuby binaries,
-`builds/`, `tmp/`, `logs/`, docs, and samples). Uses the global version by
-default; pass `--version <version>` for a specific one (tier-resolved, so
-`--version 7.11-pro` works too), or `--skip-gitignore` to skip writing the
-`.gitignore`.
-
-### `drenv use [version]`
-
-Switches the current project to a registered DragonRuby version, preserving the
-`mygame` directory. Defaults to the latest installed version; pass a version
-(tier-resolved, e.g. `drenv use 7.11-pro`) for a specific one. Asks for
-confirmation first.
-
-### `drenv run [args...]`
-
-Syncs the current project's dependencies and launches it with DragonRuby. While
-the game runs, drenv watches any `path:` dependencies and re-vendors them as you
-edit, so changes hot-reload into the running game — handy when developing a
-library alongside it. Pass `--no-watch` to turn that off (`--frozen` skips it
-too). Extra arguments are forwarded to the `dragonruby` binary.
-
-## Managing Dependencies
-
-drenv vendors dependencies into your game, bundler-style. Declare them in
-`mygame/drenv.toml` and drenv resolves them into `mygame/vendor/`, pins them in
-`mygame/drenv.lock`, and generates `mygame/app/drenv_bundle.rb` with the
-matching `require` lines.
-
-```toml
-# mygame/drenv.toml
-[dependencies.conjuration]
-github = "Nitemaeric/conjuration"   # entrypoint resolved from the library
-
-[dependencies.draco]
-github = "guitsaru/draco"
-tag = "v0.7.0"
-entrypoint = "draco.rb"             # ...or pin it explicitly
-
-[dependencies.local_lib]
-path = "../local_lib"
-```
-
-Each dependency declares exactly one source — `github`, `url`, `git`, or `path`.
-The `entrypoint` is optional: drenv resolves it from the library's own
-[`[package]`](#publishing-a-library) declaration, or by convention
-(`lib/<name>.rb`, then `<name>.rb`). You can edit `drenv.toml` by hand or manage
-it with `drenv add` / `drenv remove`. Either way, add a single line to the top
-of `mygame/app/main.rb`:
+then require the generated bundle once, at the top of `mygame/app/main.rb`:
 
 ```ruby
 require 'app/drenv_bundle.rb'
 ```
 
-Commit `drenv.toml` and `drenv.lock`. drenv keeps `mygame/vendor/` out of
-version control for you with a generated `vendor/.gitignore`, since vendored
-dependencies are reproducible from the lockfile.
+`drenv run` re-vendors everything before launching. Commit `drenv.toml` and
+`drenv.lock` — the vendored copies are reproducible from the lockfile and stay
+out of git. See [Managing dependencies](docs/dependencies.md) for the
+`drenv.toml` format, entrypoint resolution, publishing a library, and CI.
 
-### `drenv add <source>`
+## Commands
 
-Adds a dependency to `mygame/drenv.toml` and vendors it. The source is
-`kind:value`:
+Run `drenv <command> --help` for flags and details.
 
-```sh
-drenv add github:Nitemaeric/conjuration        # entrypoint resolved for you
-drenv add github:guitsaru/draco@v0.7.0
-drenv add git:https://gitlab.com/me/my_engine.git --branch main
-drenv add path:../local_lib
-```
+**Engine management**
 
-Pass `-e, --entrypoint` only when the library doesn't declare or follow a
-conventional entrypoint, `-n, --name` to override the derived name, and
-`--tag`/`--branch`/`--ref` to pin a `github`/`git` revision.
+| Command            | Description                                     |
+| ------------------ | ----------------------------------------------- |
+| `install`          | Download the latest DragonRuby (prompts a tier) |
+| `register <path>`  | Register a local install (a `.zip` or a folder) |
+| `versions`         | List installed versions                         |
+| `global [version]` | Get or set the default version                  |
+| `changelog [ver]`  | Print a version's changelog                     |
 
-### `drenv remove <name>`
+**Project management**
 
-Removes a dependency from `mygame/drenv.toml`, deletes its vendored copy, and
-updates the lock.
+| Command           | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `new <name>`      | Scaffold a new project                         |
+| `use [version]`   | Switch the current project's version           |
+| `run [args...]`   | Vendor dependencies and launch the game        |
+| `publish [args…]` | Verify dependencies, then `dragonruby-publish` |
 
-### `drenv bundle`
+**Dependency management**
 
-Resolves every dependency in `mygame/drenv.toml`, vendors it into
-`mygame/vendor/`, and writes `mygame/drenv.lock` and
-`mygame/app/drenv_bundle.rb`. `drenv run` does this for you before launching;
-run it directly when you only want to refresh dependencies. Pass `--frozen`
-(also valid on `drenv run`) to verify against the lockfile without updating it —
-handy in CI.
+| Command         | Description                                |
+| --------------- | ------------------------------------------ |
+| `add <source>`  | Add and vendor a dependency                |
+| `remove <name>` | Remove a dependency                        |
+| `bundle`        | Re-vendor from `drenv.toml` / the lockfile |
 
-### `drenv publish [args...]`
+**Managing drenv**
 
-Verifies dependencies against the lockfile (like `--frozen`), then runs
-`dragonruby-publish` on `mygame`, forwarding any arguments. So
-`drenv publish --package` packages locally and `drenv publish` publishes to
-itch.io — always shipping exactly what's locked.
-
-### Publishing a library
-
-If you maintain a DragonRuby library, add a `[package]` section to a
-`drenv.toml` at your repo root so consumers can `drenv add` it with no extra
-flags:
-
-```toml
-[package]
-root = "lib"                  # only this directory is vendored (default ".")
-entrypoint = "conjuration.rb" # the file to require, relative to root
-```
-
-Without it, drenv falls back to convention — `lib/<name>.rb`, then `<name>.rb` —
-so many libraries (a `lib/<name>.rb` layout) work with zero configuration.
-
-## Managing drenv
-
-### `drenv self-update`
-
-Downloads and installs the latest version of **drenv**, replacing the current
-binary in place.
+| Command       | Description         |
+| ------------- | ------------------- |
+| `self-update` | Update drenv itself |
 
 ---
 
-Tested on macOS (Apple Silicon) with DragonRuby standard 5.32, 6.3, 6.4, and
-6.18.
+Built with [Deno](https://deno.com). Tested on macOS (Apple Silicon) with
+DragonRuby 5.32, 6.3, 6.4, and 6.18.

--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ Run `drenv <command> --help` for flags and details.
 ---
 
 Built with [Deno](https://deno.com). Tested on macOS (Apple Silicon) with
-DragonRuby 5.32, 6.3, 6.4, and 6.18.
+DragonRuby 5.32, 6.3, 6.4, 6.18, and 7.11.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,97 @@
+# Managing dependencies
+
+drenv vendors dependencies into your game, Bundler-style. Declare them in
+`mygame/drenv.toml` and drenv resolves them into `mygame/vendor/`, pins them in
+`mygame/drenv.lock`, and generates `mygame/app/drenv_bundle.rb` with the
+matching `require` lines.
+
+```toml
+# mygame/drenv.toml
+[dependencies.conjuration]
+github = "Nitemaeric/conjuration"   # entrypoint resolved from the library
+
+[dependencies.draco]
+github = "guitsaru/draco"
+tag = "v0.7.0"
+entrypoint = "draco.rb"             # ...or pin it explicitly
+
+[dependencies.local_lib]
+path = "../local_lib"
+```
+
+Each dependency declares exactly one source — `github`, `url`, `git`, or `path`.
+The `entrypoint` is optional: drenv resolves it from the library's own
+[`[package]`](#publishing-a-library) declaration, or by convention
+(`lib/<name>.rb`, then `<name>.rb`). You can edit `drenv.toml` by hand or manage
+it with `drenv add` / `drenv remove`. Either way, add a single line to the top
+of `mygame/app/main.rb`:
+
+```ruby
+require 'app/drenv_bundle.rb'
+```
+
+Commit `drenv.toml` and `drenv.lock`. drenv keeps `mygame/vendor/` out of
+version control for you with a generated `vendor/.gitignore`, since vendored
+dependencies are reproducible from the lockfile.
+
+## Commands
+
+### `drenv add <source>`
+
+Adds a dependency to `mygame/drenv.toml` and vendors it. The source is
+`kind:value`:
+
+```sh
+drenv add github:Nitemaeric/conjuration        # entrypoint resolved for you
+drenv add github:guitsaru/draco@v0.7.0
+drenv add git:https://gitlab.com/me/my_engine.git --branch main
+drenv add path:../local_lib
+```
+
+Pass `-e, --entrypoint` only when the library doesn't declare or follow a
+conventional entrypoint, `-n, --name` to override the derived name, and
+`--tag`/`--branch`/`--ref` to pin a `github`/`git` revision.
+
+### `drenv remove <name>`
+
+Removes a dependency from `mygame/drenv.toml`, deletes its vendored copy, and
+updates the lock.
+
+### `drenv bundle`
+
+Resolves every dependency in `mygame/drenv.toml`, vendors it into
+`mygame/vendor/`, and writes `mygame/drenv.lock` and
+`mygame/app/drenv_bundle.rb`. `drenv run` does this for you before launching;
+run it directly when you only want to refresh dependencies. Pass `--frozen`
+(also valid on `drenv run`) to verify against the lockfile without updating it —
+handy in CI.
+
+### `drenv run [args...]`
+
+Syncs dependencies, then launches the project with DragonRuby. While the game
+runs, drenv watches any `path:` dependencies and re-vendors them as you edit, so
+changes hot-reload into the running game — handy when developing a library
+alongside it. Pass `--no-watch` to turn that off (`--frozen` skips it too).
+Extra arguments are forwarded to the `dragonruby` binary.
+
+### `drenv publish [args...]`
+
+Verifies dependencies against the lockfile (like `--frozen`), then runs
+`dragonruby-publish` on `mygame`, forwarding any arguments. `drenv publish`
+ships to itch.io and `drenv publish --package` packages locally — always
+shipping exactly what's locked.
+
+## Publishing a library
+
+If you maintain a DragonRuby library, add a `[package]` section to a
+`drenv.toml` at your repo root so consumers can `drenv add` it with no extra
+flags:
+
+```toml
+[package]
+root = "lib"                  # only this directory is vendored (default ".")
+entrypoint = "conjuration.rb" # the file to require, relative to root
+```
+
+Without it, drenv falls back to convention — `lib/<name>.rb`, then `<name>.rb` —
+so many libraries (a `lib/<name>.rb` layout) work with zero configuration.

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,67 @@
+# Managing DragonRuby versions
+
+drenv keeps every DragonRuby install under `~/.drenv/versions` and lets you pick
+which one each project uses.
+
+## Tiers install side by side
+
+`drenv install` prompts for your tier the first time and remembers it; pass
+`--tier standard|indie|pro` to choose or switch. Standard downloads from
+[itch.io](https://itch.io) (stored as a revocable API key, never a plaintext
+password); indie and pro from [dragonruby.org](https://dragonruby.org) (your
+account email is cached, and only the password is prompted for).
+
+Each version+tier gets its own directory — standard keeps the bare version
+(`7.11`), while indie and pro are suffixed (`7.11-pro`, `7.11-indie`) — so
+installing pro doesn't clobber your standard copy of the same version.
+
+## Referring to a version
+
+A bare version resolves to the **highest tier you have installed**: `7.11` picks
+`7.11-pro` if present, then `7.11-indie`, then `7.11` (standard). To pin a tier,
+name it — `7.11-pro`, or `7.11-standard` for the standard build. This resolution
+applies everywhere a version is accepted (`global`, `new --version`, `use`), and
+`drenv use` with no version switches to your highest installed tier.
+
+## Commands
+
+### `drenv install [--tier <tier>]`
+
+Downloads and installs the latest DragonRuby GTK. Prompts for your tier the
+first time and remembers it. Requires a DragonRuby purchase — itch.io for
+standard, a dragonruby.org subscription for indie/pro. Your first install is
+also set as the global default.
+
+### `drenv register <path> [--tier <tier>]`
+
+Registers a local install manually. The path can be a `.zip` file or a directory
+containing the `dragonruby` executable — handy if you already have a copy
+downloaded. Pass `--tier indie|pro` to file it under that tier (defaults to
+`standard`).
+
+### `drenv global [version]`
+
+Sets the global DragonRuby version used when creating new projects. Without
+arguments, prints the current global version.
+
+### `drenv versions`
+
+Lists all installed versions, with the current project's version marked and each
+tier labelled:
+
+```
+  7.11 Pro
+* 6.4
+  5.32
+```
+
+### `drenv changelog [version]`
+
+Prints the changelog entry for a version (defaults to the latest installed).
+
+### `drenv use [version]`
+
+Switches the current project to a registered version, preserving the `mygame`
+directory. Defaults to your highest installed tier; pass a version
+(tier-resolved, e.g. `drenv use 7.11-pro`) for a specific one. Asks for
+confirmation first.


### PR DESCRIPTION
## What

Rewrites the README as a getting-started doc (243 → ~120 lines) and moves the deeper reference into `docs/`.

**README now:** intro → Install → **Quick start** (install → new → run) → Dependencies (the essential add/require/run loop) → a compact **Commands** table grouped like `drenv --help` → self-update.

**New docs, linked from the README:**
- [`docs/versions.md`](docs/versions.md) — tiers, version resolution, and the engine commands (install/register/global/versions/changelog/use)
- [`docs/dependencies.md`](docs/dependencies.md) — `drenv.toml` format, entrypoint resolution, add/remove/bundle/run/publish, publishing a library, CI/`--frozen`

## Why

The old README had grown into a full reference manual. New users had to scroll past tier-directory internals and lockfile mechanics to find "how do I run my game." This keeps the front page focused on the golden path while preserving every bit of the reference material in `docs/`.

Docs-only — no code or version change.