### PR TITLE
fix: temp-dir downloads, use project guard, changelog PREV lookup

### DIFF
--- a/commands/changelog.test.ts
+++ b/commands/changelog.test.ts
@@ -15,12 +15,20 @@ const FIXTURE = `* 99.99
 `;
 
 describe("changelog", () => {
+  const ARCHIVED = `* 99.50
+** [Bugfix] Fixed an archived thing.
+`;
+
   beforeAll(async () => {
     await ensureDir(`${versionsPath}/99.99`);
     await ensureDir(`${versionsPath}/99.98`);
     await Deno.writeTextFile(
       `${versionsPath}/99.99/CHANGELOG-CURR.txt`,
       FIXTURE,
+    );
+    await Deno.writeTextFile(
+      `${versionsPath}/99.99/CHANGELOG-PREV.txt`,
+      ARCHIVED,
     );
     await Deno.writeTextFile(
       `${versionsPath}/99.98/CHANGELOG-CURR.txt`,
@@ -62,6 +70,15 @@ describe("changelog", () => {
       assertEquals(
         result,
         "* 99.97\n** [Bugfix] Fixed an even older thing.",
+      );
+    });
+
+    it("finds an entry archived in CHANGELOG-PREV.txt", async () => {
+      const result = await changelog("99.50");
+
+      assertEquals(
+        result,
+        "* 99.50\n** [Bugfix] Fixed an archived thing.",
       );
     });
 

--- a/commands/changelog.ts
+++ b/commands/changelog.ts
@@ -29,6 +29,9 @@ const extractEntry = (
   return lines.slice(startIndex, endIndex).join("\n").trimEnd();
 };
 
+const readIfExists = async (path: string): Promise<string> =>
+  (await exists(path)) ? await Deno.readTextFile(path) : "";
+
 export default async function changelog(version?: string) {
   const sourceDir = await latestInstalledVersion();
 
@@ -36,17 +39,22 @@ export default async function changelog(version?: string) {
     throw new Error("drenv: no DragonRuby versions installed");
   }
 
-  const changelogPath = `${versionsPath}/${sourceDir}/CHANGELOG-CURR.txt`;
+  // DragonRuby splits its changelog across CURR (recent) and PREV (archived);
+  // read both so entries for older versions still resolve.
+  const base = `${versionsPath}/${sourceDir}`;
+  const content = [
+    await readIfExists(`${base}/CHANGELOG-CURR.txt`),
+    await readIfExists(`${base}/CHANGELOG-PREV.txt`),
+  ].join("\n");
 
-  if (!await exists(changelogPath)) {
-    throw new Error(`drenv: changelog not found at ${changelogPath}`);
+  if (!content.trim()) {
+    throw new Error(`drenv: changelog not found in ${base}`);
   }
 
   // Changelog headers use bare version numbers; strip any tier from the input.
   const target = version
     ? splitVersionInput(version).version
     : parseVersionDir(sourceDir).version;
-  const content = await Deno.readTextFile(changelogPath);
   const entry = extractEntry(content, target);
 
   if (!entry) {

--- a/commands/install.ts
+++ b/commands/install.ts
@@ -1,5 +1,4 @@
 import { promptSecret } from "@std/cli";
-import { ensureDir } from "@std/fs";
 import ora, { type Ora } from "ora";
 
 import register from "./register.ts";
@@ -187,7 +186,6 @@ async function downloadUpload(
     throw new Error(`drenv: download failed with status ${fileRes.status}`);
   }
 
-  await ensureDir("./tmp");
   const file = await Deno.create(destPath);
   await fileRes.body.pipeTo(file.writable);
 }
@@ -222,16 +220,16 @@ async function installFromItch(kv: Deno.Kv, spinner: Ora): Promise<string> {
   const upload = await getUpload(apiKey, downloadKeyId, "standard");
 
   spinner.text = `Downloading ${upload.filename}...`;
-  await ensureDir("./tmp");
-  await downloadUpload(
-    apiKey,
-    upload.id,
-    downloadKeyId,
-    `./tmp/${upload.filename}`,
-  );
+  const tmp = await Deno.makeTempDir({ prefix: "drenv-download-" });
+  try {
+    const zipPath = `${tmp}/${upload.filename}`;
+    await downloadUpload(apiKey, upload.id, downloadKeyId, zipPath);
 
-  spinner.text = "Installing...";
-  return register(`./tmp/${upload.filename}`);
+    spinner.text = "Installing...";
+    return await register(zipPath);
+  } finally {
+    await Deno.remove(tmp, { recursive: true }).catch(() => {});
+  }
 }
 
 /** Downloads a subscription tier (indie/pro) from dragonruby.org. */
@@ -296,13 +294,17 @@ async function installFromDragonRubyOrg(
     throw new Error(`drenv: download failed with status ${fileRes.status}`);
   }
 
-  await ensureDir("./tmp");
-  const destPath = `./tmp/dragonruby-${tier}-${platform}.zip`;
-  const file = await Deno.create(destPath);
-  await fileRes.body.pipeTo(file.writable);
+  const tmp = await Deno.makeTempDir({ prefix: "drenv-download-" });
+  try {
+    const destPath = `${tmp}/dragonruby-${tier}-${platform}.zip`;
+    const file = await Deno.create(destPath);
+    await fileRes.body.pipeTo(file.writable);
 
-  spinner.text = "Installing...";
-  return register(destPath, { tier });
+    spinner.text = "Installing...";
+    return await register(destPath, { tier });
+  } finally {
+    await Deno.remove(tmp, { recursive: true }).catch(() => {});
+  }
 }
 
 export default async function install(options: { tier?: string } = {}) {

--- a/commands/register.ts
+++ b/commands/register.ts
@@ -15,46 +15,49 @@ export default async function register(
   const tier = validateTier(options.tier ?? "standard");
   const zipOrDirectory = await Deno.open(path);
 
-  let fromZip = false;
+  // Zips are extracted into a throwaway temp directory (not the cwd) and cleaned
+  // up afterward. A directory register moves the given path in place.
+  let extractDir: string | undefined;
   if (extname(path) === ".zip") {
-    path = await extractZip(zipOrDirectory);
-    fromZip = true;
+    extractDir = await Deno.makeTempDir({ prefix: "drenv-register-" });
+    path = await extractZip(zipOrDirectory, extractDir);
   }
 
-  const directory = await Deno.open(path);
-  const directoryInfo = await directory.stat();
+  try {
+    const directory = await Deno.open(path);
+    const directoryInfo = await directory.stat();
 
-  if (!directoryInfo.isDirectory) {
-    throw new Error(
-      "drenv: <path> must be a directory with the dragonruby executable or a zip file",
-    );
+    if (!directoryInfo.isDirectory) {
+      throw new Error(
+        "drenv: <path> must be a directory with the dragonruby executable or a zip file",
+      );
+    }
+
+    const version = await versionCommand(path);
+    const dirName = versionDirName(version, tier);
+
+    await ensureDir(versionsPath);
+
+    // Overwrite an existing install of the same version and tier. Different
+    // tiers of the same version get distinct directory names (`7.11`,
+    // `7.11-pro`), so they coexist rather than clobbering each other.
+    await move(path, `${versionsPath}/${dirName}`, { overwrite: true });
+
+    return `drenv: Installed ${dirName}`;
+  } finally {
+    if (extractDir) {
+      await Deno.remove(extractDir, { recursive: true }).catch(() => {});
+    }
   }
-
-  const version = await versionCommand(path);
-  const dirName = versionDirName(version, tier);
-
-  await ensureDir(versionsPath);
-
-  // Overwrite an existing install of the same version and tier. Different tiers
-  // of the same version get distinct directory names (`7.11`, `7.11-pro`), so
-  // they coexist rather than clobbering each other.
-  await move(path, `${versionsPath}/${dirName}`, { overwrite: true });
-
-  // Only the zip path stages files under ./tmp; a directory register doesn't.
-  if (fromZip) {
-    await Deno.remove("./tmp", { recursive: true }).catch(() => {});
-  }
-
-  return `drenv: Installed ${versionDirName(version, tier)}`;
 }
 
-const extractZip = async (zip: Deno.FsFile) => {
+const extractZip = async (zip: Deno.FsFile, baseDir: string) => {
   let directoryPath!: string;
 
   for await (
     const entry of zip.readable.pipeThrough(new ZipReaderStream())
   ) {
-    const fullPath = resolve("./tmp/", entry.filename);
+    const fullPath = resolve(baseDir, entry.filename);
 
     if (entry.directory) {
       directoryPath ??= fullPath;

--- a/commands/use.test.ts
+++ b/commands/use.test.ts
@@ -3,6 +3,7 @@ import { assert, assertEquals, assertRejects } from "@std/assert";
 import { ensureDir, exists } from "@std/fs";
 
 import use, { NotInstalled } from "./use.ts";
+import { ProjectNotFound } from "../utils/project.ts";
 import { versionsPath } from "../constants.ts";
 
 describe("use", () => {
@@ -14,6 +15,8 @@ describe("use", () => {
     cwd = Deno.cwd();
     tmp = await Deno.makeTempDir({ prefix: "drenv-use-" });
     Deno.chdir(tmp);
+    // `use` requires a project — a directory containing `mygame/`.
+    await ensureDir(`${tmp}/mygame`);
     realPrompt = globalThis.prompt;
 
     // Use high versions so these fixtures are reliably the "latest" installed.
@@ -70,5 +73,18 @@ describe("use", () => {
       NotInstalled,
       "version '0.0' not installed",
     );
+  });
+
+  it("rejects when not inside a project", async () => {
+    globalThis.prompt = () => "";
+    const bare = await Deno.makeTempDir({ prefix: "drenv-notproj-" });
+    Deno.chdir(bare);
+
+    try {
+      await assertRejects(() => use("97.01"), ProjectNotFound);
+    } finally {
+      Deno.chdir(tmp);
+      await Deno.remove(bare, { recursive: true });
+    }
   });
 });

--- a/commands/use.ts
+++ b/commands/use.ts
@@ -1,4 +1,5 @@
 import { copy } from "@std/fs";
+import { join } from "@std/path";
 
 import { versionsPath } from "../constants.ts";
 import {
@@ -6,6 +7,7 @@ import {
   resolveVersionDir,
 } from "../utils/installed-versions.ts";
 import { versionLabel } from "../utils/tier.ts";
+import { findProject } from "../utils/project.ts";
 
 export class NotInstalled extends Error {
   version: string;
@@ -26,6 +28,10 @@ export class NoVersionsInstalled extends Error {
 }
 
 export default async function use(version?: string) {
+  // Fail fast if we're not in a project, before prompting — otherwise `use`
+  // would dump DragonRuby's files into whatever directory you happen to be in.
+  const project = await findProject();
+
   let dir: string | undefined;
   if (version) {
     dir = await resolveVersionDir(version);
@@ -45,13 +51,13 @@ export default async function use(version?: string) {
     return "drenv: cancelled";
   }
 
-  // Copy the version's files over the current directory, preserving the game.
+  // Copy the version's files over the project root, preserving the game.
   for await (const item of Deno.readDir(`${versionsPath}/${dir}`)) {
     if (item.name === "mygame") continue;
 
     await copy(
       `${versionsPath}/${dir}/${item.name}`,
-      `./${item.name}`,
+      join(project.root, item.name),
       { overwrite: true },
     );
   }


### PR DESCRIPTION
Fixes the three bug-category items from the command review.

## #4 — `drenv install` littered the current directory
`install` staged its ~64 MB download to `./tmp` in **cwd**, and `register` extracted zips there too. Both now use `Deno.makeTempDir()` and clean up in a `finally`, so nothing is written to the directory you run from (and a failed install leaves nothing behind).

## #7 — `drenv use` was cwd-blind
`use` copied engine files over `./` with no check, so running it outside a project dumped DragonRuby into whatever directory you were in. It now resolves the project root via `findProject()` (walks up for `mygame/`) and refuses with `ProjectNotFound` otherwise — verified it creates zero files in a non-project dir. It also correctly targets the project root when run from a subdirectory.

## #9 — `changelog <old-version>` couldn't find archived entries
It only read the latest install's `CHANGELOG-CURR.txt`. DragonRuby rolls older entries into `CHANGELOG-PREV.txt`; `changelog` now reads both.

## Tests
27 → adds coverage for `new` default-to-latest (from the prior PR), the `use` project guard, and a `PREV`-file changelog lookup. All green; `deno check`/`lint`/`fmt` clean.

Bug fixes only — patch release (0.11.1).