### PR TITLE
feat: add drenv uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ Run `drenv <command> --help` for flags and details.
 
 **Engine management**
 
-| Command           | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| `install`         | Download the latest DragonRuby (prompts a tier) |
-| `register <path>` | Register a local install (a `.zip` or a folder) |
-| `versions`        | List installed versions                         |
-| `changelog [ver]` | Print a version's changelog                     |
+| Command               | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `install`             | Download the latest DragonRuby (prompts a tier) |
+| `register <path>`     | Register a local install (a `.zip` or a folder) |
+| `uninstall <version>` | Remove an installed version                     |
+| `versions`            | List installed versions                         |
+| `changelog [ver]`     | Print a version's changelog                     |
 
 **Project management**
 

--- a/commands/uninstall.test.ts
+++ b/commands/uninstall.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { ensureDir, exists } from "@std/fs";
+
+import uninstall, { NotInstalled } from "./uninstall.ts";
+import { versionsPath } from "../constants.ts";
+
+describe("uninstall", () => {
+  let realPrompt: typeof globalThis.prompt;
+
+  beforeEach(async () => {
+    realPrompt = globalThis.prompt;
+    await ensureDir(`${versionsPath}/98.01`);
+    await Deno.writeTextFile(`${versionsPath}/98.01/marker.txt`, "v98.01");
+  });
+
+  afterEach(async () => {
+    globalThis.prompt = realPrompt;
+    await Deno.remove(`${versionsPath}/98.01`, { recursive: true })
+      .catch(() => {});
+  });
+
+  it("removes an installed version when confirmed", async () => {
+    globalThis.prompt = () => "y";
+
+    const message = await uninstall("98.01");
+
+    assert(!await exists(`${versionsPath}/98.01`));
+    assertStringIncludes(message ?? "", "Uninstalled");
+  });
+
+  it("cancels by default when the user doesn't confirm", async () => {
+    globalThis.prompt = () => "";
+
+    const message = await uninstall("98.01");
+
+    assertEquals(message, "drenv: cancelled");
+    assert(await exists(`${versionsPath}/98.01`));
+  });
+
+  it("skips the prompt with --yes", async () => {
+    // No prompt override — this would hang or cancel if it prompted.
+    const message = await uninstall("98.01", { yes: true });
+
+    assert(!await exists(`${versionsPath}/98.01`));
+    assertStringIncludes(message ?? "", "Uninstalled");
+  });
+
+  it("rejects an uninstalled version", async () => {
+    globalThis.prompt = () => "y";
+
+    await assertRejects(
+      () => uninstall("0.0"),
+      NotInstalled,
+      "version '0.0' not installed",
+    );
+  });
+});

--- a/commands/uninstall.ts
+++ b/commands/uninstall.ts
@@ -1,0 +1,38 @@
+import { versionsPath } from "../constants.ts";
+import { resolveVersionDir } from "../utils/installed-versions.ts";
+import { versionLabel } from "../utils/tier.ts";
+
+export class NotInstalled extends Error {
+  version: string;
+
+  constructor(version: string) {
+    super(`drenv: version '${version}' not installed`);
+
+    this.name = "NotInstalled";
+    this.version = version;
+  }
+}
+
+export default async function uninstall(
+  version: string,
+  options: { yes?: boolean } = {},
+) {
+  // Bare input resolves to the highest installed tier; a suffix pins it. The
+  // prompt shows the resolved version+tier so a destructive delete is explicit.
+  const dir = await resolveVersionDir(version);
+  if (!dir) {
+    throw new NotInstalled(version);
+  }
+
+  const label = versionLabel(dir);
+  if (!options.yes) {
+    const answer = prompt(`drenv: Uninstall version ${label}? y/N (N)`) ?? "";
+    if (!answer.trim().toLowerCase().startsWith("y")) {
+      return "drenv: cancelled";
+    }
+  }
+
+  await Deno.remove(`${versionsPath}/${dir}`, { recursive: true });
+
+  return `drenv: Uninstalled ${label}`;
+}

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -39,6 +39,14 @@ containing the `dragonruby` executable — handy if you already have a copy
 downloaded. Pass `--tier indie|pro` to file it under that tier (defaults to
 `standard`).
 
+### `drenv uninstall <version>`
+
+Removes an installed version from `~/.drenv/versions`. The version is
+tier-resolved (`7.11` picks your highest tier, `7.11-pro` pins it), and drenv
+prompts for confirmation showing exactly what will be removed; pass `-y`/`--yes`
+to skip the prompt (for scripts). Existing projects are unaffected — they carry
+their own copy of DragonRuby.
+
 ### `drenv versions`
 
 Lists all installed versions, with the current project's version marked and each

--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,7 @@ import use from "./commands/use.ts";
 import newCommand from "./commands/new.ts";
 import publish from "./commands/publish.ts";
 import register from "./commands/register.ts";
+import uninstall from "./commands/uninstall.ts";
 import remove from "./commands/remove.ts";
 import run from "./commands/run.ts";
 import selfUpdate from "./commands/self-update.ts";
@@ -97,6 +98,17 @@ program
   )
   .helpGroup(ENGINE)
   .action(actionRunner(register));
+
+program
+  .command("uninstall")
+  .argument(
+    "<version>",
+    "Version to remove (tier-resolved, e.g. 7.11 or 7.11-pro)",
+  )
+  .option("-y, --yes", "Skip the confirmation prompt")
+  .description("Remove an installed DragonRuby version")
+  .helpGroup(ENGINE)
+  .action(actionRunner(uninstall));
 
 program
   .command("versions")


### PR DESCRIPTION
Adds `drenv uninstall <version>` — closes the "no way to remove an installed version" gap from the command review (`~/.drenv/versions` used to only grow).

## Behavior
- **Tier-resolved**, like `use`/`new`: `uninstall 7.11` targets your highest installed tier; `uninstall 7.11-pro` pins it.
- **Confirms first**, showing the resolved version+tier (`Uninstall version 7.11 Pro? y/N (N)`) — defaults to **No**, since it's destructive.
- **`-y`/`--yes`** skips the prompt for scripts/CI (a plain prompt returns null when non-interactive, so without this flag uninstall would always cancel in a pipe — safe, but unscriptable).
- Existing projects are untouched; they carry their own copy of DragonRuby.

Filed under **Engine management** in the grouped help, next to `install`/`register`.

## Tests
Confirmed removal, default-cancel, `--yes` skip, and unknown-version rejection. Full suite green (28), `check`/`lint`/`fmt` clean. Live-tested `uninstall --yes` removes the dir non-interactively.

New feature → minor release (0.12.0).