### PR TITLE
feat: add drenv version

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Run `drenv <command> --help` for flags and details.
 | ----------------- | ---------------------------------------------- |
 | `new <name>`      | Scaffold a new project                         |
 | `use [version]`   | Switch the current project's version           |
+| `version`         | Print the current project's version            |
 | `run [args...]`   | Vendor dependencies and launch the game        |
 | `publish [args…]` | Verify dependencies, then `dragonruby-publish` |
 

--- a/commands/version.test.ts
+++ b/commands/version.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertEquals, assertRejects } from "@std/assert";
+import { ensureDir } from "@std/fs";
+
+import version from "./version.ts";
+import { ProjectNotFound } from "../utils/project.ts";
+
+describe("version", () => {
+  let cwd: string;
+  let tmp: string;
+
+  beforeEach(async () => {
+    cwd = Deno.cwd();
+    tmp = await Deno.makeTempDir({ prefix: "drenv-version-" });
+    Deno.chdir(tmp);
+    await ensureDir(`${tmp}/mygame`);
+  });
+
+  afterEach(async () => {
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("returns the project's DragonRuby version", async () => {
+    await Deno.writeTextFile(
+      `${tmp}/CHANGELOG-CURR.txt`,
+      "* 7.11\n** [Bugfix] something",
+    );
+
+    assertEquals(await version(), "7.11");
+  });
+
+  it("works from a subdirectory of the project", async () => {
+    await Deno.writeTextFile(`${tmp}/CHANGELOG-CURR.txt`, "* 6.4");
+    Deno.chdir(`${tmp}/mygame`);
+
+    assertEquals(await version(), "6.4");
+  });
+
+  it("rejects when not inside a project", async () => {
+    const bare = await Deno.makeTempDir({ prefix: "drenv-noproj-" });
+    Deno.chdir(bare);
+
+    try {
+      await assertRejects(() => version(), ProjectNotFound);
+    } finally {
+      Deno.chdir(tmp);
+      await Deno.remove(bare, { recursive: true });
+    }
+  });
+});

--- a/commands/version.ts
+++ b/commands/version.ts
@@ -1,0 +1,17 @@
+import { join } from "@std/path";
+
+import { findProject } from "../utils/project.ts";
+import { readVersion } from "../utils/read-version.ts";
+
+export default async function version(): Promise<string> {
+  const project = await findProject();
+  const current = await readVersion(join(project.root, "CHANGELOG-CURR.txt"));
+
+  if (!current) {
+    throw new Error(
+      "drenv: couldn't determine the project's DragonRuby version",
+    );
+  }
+
+  return current;
+}

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -68,3 +68,9 @@ Switches the current project to a registered version, preserving the `mygame`
 directory. Defaults to your highest installed tier; pass a version
 (tier-resolved, e.g. `drenv use 7.11-pro`) for a specific one. Asks for
 confirmation first.
+
+### `drenv version`
+
+Prints the DragonRuby version the current project is on (read from its
+`CHANGELOG-CURR.txt`). Works from anywhere inside the project. This is the
+project's engine version — `drenv --version` prints drenv's own version.

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,7 @@ import bundle from "./commands/bundle.ts";
 import changelog from "./commands/changelog.ts";
 import install from "./commands/install.ts";
 import use from "./commands/use.ts";
+import version from "./commands/version.ts";
 import newCommand from "./commands/new.ts";
 import publish from "./commands/publish.ts";
 import register from "./commands/register.ts";
@@ -148,6 +149,12 @@ program
   .description("Switch the current project to a DragonRuby version")
   .helpGroup(PROJECT)
   .action(actionRunner(use));
+
+program
+  .command("version")
+  .description("Print the current project's DragonRuby version")
+  .helpGroup(PROJECT)
+  .action(actionRunner(version, { skipUpdateCheck: true }));
 
 program
   .command("run")

--- a/utils/read-first-line.ts
+++ b/utils/read-first-line.ts
@@ -1,15 +1,23 @@
 export const readFirstLine = async (path: string) => {
   const file = await Deno.open(path);
 
-  const buffer = new Uint8Array(1);
-  const decoder = new TextDecoder();
-  let content = "";
+  try {
+    const buffer = new Uint8Array(1);
+    const decoder = new TextDecoder();
+    let content = "";
 
-  while (decoder.decode(buffer) != "\n") {
-    await file.read(buffer);
+    while (true) {
+      const read = await file.read(buffer);
+      if (read === null) break; // EOF — file has no trailing newline
 
-    content += decoder.decode(buffer);
+      const char = decoder.decode(buffer.subarray(0, read));
+      if (char === "\n") break;
+
+      content += char;
+    }
+
+    return content;
+  } finally {
+    file.close();
   }
-
-  return content;
 };


### PR DESCRIPTION
Adds `drenv version` — the "what version is this project on?" query from the command review.

## `drenv version`
Prints the DragonRuby version the current project is on, read from its `CHANGELOG-CURR.txt` via `findProject()` (so it works from any subdirectory). Filed under **Project management**.

It's distinct from `drenv --version`, which prints drenv's own version — noted in the docs to avoid confusion:
- `drenv --version` → `0.11.1` (drenv)
- `drenv version` → `7.11` (the project's engine)

Outside a project it errors with `ProjectNotFound`.

## Bonus fix — `readFirstLine` EOF hang
While wiring this up I hit a **latent infinite loop**: `readFirstLine` ignored EOF (`Deno.FsFile.read` returns `null` at end-of-file), so a file with **no trailing newline** looped forever re-reading a stale 1-byte buffer. This also affected `versions` (which uses the same helper). Fixed to break on EOF and close the file handle.

## Tests
29 pass — adds `version` coverage (incl. a no-trailing-newline file, which is what surfaced the hang) and the subdirectory + not-in-a-project cases.

Ships together with `uninstall` (already on main) as **0.12.0**.