### PR TITLE
feat: dependency list / update / outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ Run `drenv <command> --help` for flags and details.
 
 **Dependency management**
 
-| Command         | Description                                |
-| --------------- | ------------------------------------------ |
-| `add <source>`  | Add and vendor a dependency                |
-| `remove <name>` | Remove a dependency                        |
-| `bundle`        | Re-vendor from `drenv.toml` / the lockfile |
+| Command         | Description                                 |
+| --------------- | ------------------------------------------- |
+| `add <source>`  | Add and vendor a dependency                 |
+| `remove <name>` | Remove a dependency                         |
+| `list`          | List dependencies and their locked revs     |
+| `update [name]` | Bump dependencies to their latest           |
+| `outdated`      | Show which dependencies have upstream moves |
+| `bundle`        | Re-vendor from `drenv.toml` / the lockfile  |
 
 **Managing drenv**
 

--- a/commands/list.test.ts
+++ b/commands/list.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertStringIncludes } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+import list from "./list.ts";
+import { bundle } from "../utils/bundler.ts";
+import type { Project } from "../utils/project.ts";
+
+/** Builds a tmp project with one path dependency and returns it. */
+const scaffold = async (
+  prefix: string,
+): Promise<{ tmp: string; project: Project }> => {
+  const tmp = await Deno.makeTempDir({ prefix });
+
+  await ensureDir(join(tmp, "lib"));
+  await Deno.writeTextFile(join(tmp, "lib", "conjuration.rb"), "# lib\n");
+
+  const mygame = join(tmp, "game", "mygame");
+  await ensureDir(join(mygame, "app"));
+  await Deno.writeTextFile(
+    join(mygame, "drenv.toml"),
+    '[dependencies.conjuration]\npath = "../../lib"\nentrypoint = "conjuration.rb"\n',
+  );
+  await Deno.writeTextFile(
+    join(mygame, "app", "main.rb"),
+    "def tick args\nend\n",
+  );
+
+  return {
+    tmp,
+    project: {
+      root: join(tmp, "game"),
+      mygame,
+      manifestPath: join(mygame, "drenv.toml"),
+      lockPath: join(mygame, "drenv.lock"),
+    },
+  };
+};
+
+describe("list", () => {
+  let cwd: string;
+  let tmp: string;
+  let project: Project;
+  let logs: string[];
+  let realLog: typeof console.log;
+
+  beforeEach(async () => {
+    cwd = Deno.cwd();
+    ({ tmp, project } = await scaffold("drenv-list-"));
+    await bundle(project);
+    Deno.chdir(project.root);
+
+    logs = [];
+    realLog = console.log;
+    console.log = (...args) => logs.push(args.map(String).join(" "));
+  });
+
+  afterEach(async () => {
+    console.log = realLog;
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("lists each dependency with its source", async () => {
+    await list();
+
+    const out = logs.join("\n");
+    assertStringIncludes(out, "conjuration");
+    assertStringIncludes(out, "path:../../lib");
+  });
+});

--- a/commands/list.ts
+++ b/commands/list.ts
@@ -1,0 +1,61 @@
+import { exists } from "@std/fs";
+
+import { findProject } from "../utils/project.ts";
+import {
+  type DependencySpec,
+  readManifest,
+  sourceKind,
+} from "../utils/manifest.ts";
+import { readLock } from "../utils/lockfile.ts";
+
+/** A `kind:value` description of a dependency's source, with any pin. */
+export const describeSource = (spec: DependencySpec): string => {
+  const kind = sourceKind(spec);
+  const pin = spec.tag
+    ? `@${spec.tag}`
+    : spec.branch
+    ? `#${spec.branch}`
+    : spec.ref
+    ? `@${spec.ref}`
+    : "";
+  return `${kind}:${spec[kind]}${pin}`;
+};
+
+const shortRef = (ref: string | undefined): string =>
+  ref ? ref.slice(0, 7) : "—";
+
+export default async function list() {
+  const project = await findProject();
+
+  if (!await exists(project.manifestPath)) {
+    throw new Error(
+      "drenv: no mygame/drenv.toml — add a dependency with `drenv add <source>`",
+    );
+  }
+
+  const manifest = await readManifest(project.manifestPath);
+  if (manifest.dependencies.length === 0) {
+    return "drenv: no dependencies declared";
+  }
+
+  const lock = await readLock(project.lockPath);
+
+  const rows = manifest.dependencies.map((spec) => ({
+    name: spec.name,
+    source: describeSource(spec),
+    ref: shortRef(
+      lock?.dependencies.find((dep) => dep.name === spec.name)?.ref,
+    ),
+  }));
+
+  const nameWidth = Math.max(...rows.map((row) => row.name.length));
+  const sourceWidth = Math.max(...rows.map((row) => row.source.length));
+
+  for (const row of rows) {
+    console.log(
+      `  ${row.name.padEnd(nameWidth)}  ${
+        row.source.padEnd(sourceWidth)
+      }  ${row.ref}`,
+    );
+  }
+}

--- a/commands/outdated.test.ts
+++ b/commands/outdated.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertEquals, assertRejects } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+import outdated from "./outdated.ts";
+import { bundle } from "../utils/bundler.ts";
+import type { Project } from "../utils/project.ts";
+
+describe("outdated", () => {
+  let cwd: string;
+  let tmp: string;
+  let project: Project;
+
+  beforeEach(async () => {
+    cwd = Deno.cwd();
+    tmp = await Deno.makeTempDir({ prefix: "drenv-outdated-" });
+
+    await ensureDir(join(tmp, "lib"));
+    await Deno.writeTextFile(join(tmp, "lib", "conjuration.rb"), "# lib\n");
+
+    const mygame = join(tmp, "game", "mygame");
+    await ensureDir(join(mygame, "app"));
+    await Deno.writeTextFile(
+      join(mygame, "drenv.toml"),
+      '[dependencies.conjuration]\npath = "../../lib"\nentrypoint = "conjuration.rb"\n',
+    );
+    await Deno.writeTextFile(
+      join(mygame, "app", "main.rb"),
+      "def tick args\nend\n",
+    );
+
+    project = {
+      root: join(tmp, "game"),
+      mygame,
+      manifestPath: join(mygame, "drenv.toml"),
+      lockPath: join(mygame, "drenv.lock"),
+    };
+    Deno.chdir(project.root);
+  });
+
+  afterEach(async () => {
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("reports all up to date when only path deps are present", async () => {
+    await bundle(project);
+
+    // Path deps aren't revision-tracked, so there's nothing to flag.
+    assertEquals(await outdated(), "drenv: all dependencies up to date");
+  });
+
+  it("rejects when there is no lockfile", async () => {
+    await assertRejects(() => outdated(), Error, "no lockfile");
+  });
+});

--- a/commands/outdated.ts
+++ b/commands/outdated.ts
@@ -1,0 +1,53 @@
+import { exists } from "@std/fs";
+
+import { findProject } from "../utils/project.ts";
+import { readManifest, sourceKind } from "../utils/manifest.ts";
+import { readLock } from "../utils/lockfile.ts";
+import { remoteRef } from "../utils/sources/mod.ts";
+
+const shortRef = (ref: string): string => ref.slice(0, 7);
+
+export default async function outdated() {
+  const project = await findProject();
+
+  if (!await exists(project.manifestPath)) {
+    throw new Error(
+      "drenv: no mygame/drenv.toml — add a dependency with `drenv add <source>`",
+    );
+  }
+
+  const manifest = await readManifest(project.manifestPath);
+  const lock = await readLock(project.lockPath);
+
+  if (!lock) {
+    throw new Error("drenv: no lockfile — run `drenv bundle` first");
+  }
+
+  const stale: { name: string; from: string; to: string }[] = [];
+
+  for (const spec of manifest.dependencies) {
+    // path/url sources aren't revision-tracked, so there's nothing to compare.
+    if (sourceKind(spec) === "path" || sourceKind(spec) === "url") continue;
+
+    const locked = lock.dependencies.find((dep) => dep.name === spec.name);
+    const current = await remoteRef(spec);
+
+    if (locked?.ref && current && current !== locked.ref) {
+      stale.push({ name: spec.name, from: locked.ref, to: current });
+    }
+  }
+
+  if (stale.length === 0) {
+    return "drenv: all dependencies up to date";
+  }
+
+  const nameWidth = Math.max(...stale.map((row) => row.name.length));
+  for (const row of stale) {
+    console.log(
+      `  ${row.name.padEnd(nameWidth)}  ${shortRef(row.from)} → ${
+        shortRef(row.to)
+      }`,
+    );
+  }
+  console.log("\nRun `drenv update [name]` to upgrade.");
+}

--- a/commands/update.test.ts
+++ b/commands/update.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { ensureDir, exists } from "@std/fs";
+import { join } from "@std/path";
+
+import update from "./update.ts";
+import { bundle } from "../utils/bundler.ts";
+import type { Project } from "../utils/project.ts";
+
+describe("update", () => {
+  let cwd: string;
+  let tmp: string;
+  let project: Project;
+  let logs: string[];
+  let realLog: typeof console.log;
+
+  beforeEach(async () => {
+    cwd = Deno.cwd();
+    tmp = await Deno.makeTempDir({ prefix: "drenv-update-" });
+
+    await ensureDir(join(tmp, "lib"));
+    await Deno.writeTextFile(join(tmp, "lib", "conjuration.rb"), "# lib\n");
+
+    const mygame = join(tmp, "game", "mygame");
+    await ensureDir(join(mygame, "app"));
+    await Deno.writeTextFile(
+      join(mygame, "drenv.toml"),
+      '[dependencies.conjuration]\npath = "../../lib"\nentrypoint = "conjuration.rb"\n',
+    );
+    await Deno.writeTextFile(
+      join(mygame, "app", "main.rb"),
+      "def tick args\nend\n",
+    );
+
+    project = {
+      root: join(tmp, "game"),
+      mygame,
+      manifestPath: join(mygame, "drenv.toml"),
+      lockPath: join(mygame, "drenv.lock"),
+    };
+    Deno.chdir(project.root);
+
+    logs = [];
+    realLog = console.log;
+    console.log = (...args) => logs.push(args.map(String).join(" "));
+  });
+
+  afterEach(async () => {
+    console.log = realLog;
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("resolves and reports newly added dependencies", async () => {
+    await update();
+
+    const out = logs.join("\n");
+    assertStringIncludes(out, "conjuration");
+    assertStringIncludes(out, "added");
+    assert(await exists(join(project.mygame, "drenv.lock")));
+  });
+
+  it("reports up to date when nothing changed", async () => {
+    await bundle(project);
+
+    // A path dependency has no revision, so re-resolving changes nothing.
+    assertEquals(await update("conjuration"), "drenv: already up to date");
+  });
+
+  it("rejects an unknown dependency name", async () => {
+    await bundle(project);
+
+    await assertRejects(
+      () => update("nope"),
+      Error,
+      "no dependency named 'nope'",
+    );
+  });
+});

--- a/commands/update.ts
+++ b/commands/update.ts
@@ -1,0 +1,55 @@
+import { exists } from "@std/fs";
+
+import { findProject } from "../utils/project.ts";
+import { bundle, updateDependency } from "../utils/bundler.ts";
+import { type Lockfile, readLock } from "../utils/lockfile.ts";
+
+const shortRef = (ref: string | undefined): string =>
+  ref ? ref.slice(0, 7) : "local";
+
+/** Lines describing what changed between two locks, newest resolution wins. */
+const diff = (before: Lockfile | null, after: Lockfile): string[] => {
+  const changes: string[] = [];
+
+  for (const dep of after.dependencies) {
+    const prev = before?.dependencies.find((d) => d.name === dep.name);
+
+    if (!prev) {
+      changes.push(`  ${dep.name}  added (${shortRef(dep.ref)})`);
+    } else if (prev.ref !== dep.ref) {
+      changes.push(
+        `  ${dep.name}  ${shortRef(prev.ref)} → ${shortRef(dep.ref)}`,
+      );
+    }
+  }
+
+  return changes;
+};
+
+export default async function update(name?: string) {
+  const project = await findProject();
+
+  if (!await exists(project.manifestPath)) {
+    throw new Error(
+      "drenv: no mygame/drenv.toml — add a dependency with `drenv add <source>`",
+    );
+  }
+
+  const before = await readLock(project.lockPath);
+  const log = (message: string) => console.log(message);
+
+  // Updating one dependency needs a baseline lock to preserve the others;
+  // without it (or without a name), fall back to a full re-resolve.
+  const { lock: after } = name && before
+    ? await updateDependency(project, name, { log })
+    : await bundle(project, { log });
+
+  const changes = diff(before, after);
+
+  if (changes.length === 0) {
+    return "drenv: already up to date";
+  }
+
+  console.log("drenv: updated");
+  for (const change of changes) console.log(change);
+}

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -57,6 +57,31 @@ conventional entrypoint, `-n, --name` to override the derived name, and
 Removes a dependency from `mygame/drenv.toml`, deletes its vendored copy, and
 updates the lock.
 
+### `drenv list`
+
+Lists the project's dependencies with their source and the short revision each
+is locked to (path deps show `—`, since they aren't revision-tracked).
+
+```
+conjuration  github:Nitemaeric/conjuration  a1b2c3d
+draco        github:guitsaru/draco@v0.7.0   e4f5a6b
+local_lib    path:../local_lib              —
+```
+
+### `drenv update [name]`
+
+Re-resolves dependencies to their latest allowed revision and rewrites the
+lockfile, reporting what moved. With a name, only that dependency is updated and
+the rest stay pinned to their locked revisions; without one, everything is
+re-resolved. Pinned deps (a `tag` or `ref`) don't move; floating ones (a
+`branch`, or no pin) advance to the newest commit.
+
+### `drenv outdated`
+
+Checks each remote dependency's upstream against the lockfile and lists the ones
+whose tracked revision has moved on, so you can decide what to `drenv update`.
+Path and URL sources aren't revision-tracked and are skipped.
+
 ### `drenv bundle`
 
 Resolves every dependency in `mygame/drenv.toml`, vendors it into

--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,9 @@ import { greaterThan, tryParse } from "@std/semver";
 import config from "./deno.json" with { type: "json" };
 
 import add from "./commands/add.ts";
+import list from "./commands/list.ts";
+import update from "./commands/update.ts";
+import outdated from "./commands/outdated.ts";
 import bundle from "./commands/bundle.ts";
 import changelog from "./commands/changelog.ts";
 import install from "./commands/install.ts";
@@ -205,6 +208,27 @@ program
   .description("Remove a dependency from mygame/drenv.toml")
   .helpGroup(DEPENDENCIES)
   .action(actionRunner(remove));
+
+program
+  .command("list")
+  .description("List the project's dependencies and their locked revisions")
+  .helpGroup(DEPENDENCIES)
+  .action(actionRunner(list));
+
+program
+  .command("update")
+  .argument("[name]", "Dependency to update (default: all)")
+  .description(
+    "Re-resolve dependencies to their latest and update the lockfile",
+  )
+  .helpGroup(DEPENDENCIES)
+  .action(actionRunner(update));
+
+program
+  .command("outdated")
+  .description("Show dependencies whose upstream has moved past the lockfile")
+  .helpGroup(DEPENDENCIES)
+  .action(actionRunner(outdated));
 
 program
   .command("bundle")

--- a/utils/bundler.ts
+++ b/utils/bundler.ts
@@ -113,6 +113,53 @@ export const reconcile = async (
   return { lock, needsRequireLine: await needsRequireLine(project) };
 };
 
+/**
+ * Re-resolves a single dependency to its latest, keeping every other dependency
+ * at its currently locked revision. Any manifest dependency not yet in the lock
+ * is resolved too, so the lock and bundle stay complete.
+ */
+export const updateDependency = async (
+  project: Project,
+  name: string,
+  options: Options = {},
+): Promise<BundleResult> => {
+  const log = options.log ?? (() => {});
+  const manifest = await readManifest(project.manifestPath);
+
+  if (!manifest.dependencies.some((dep) => dep.name === name)) {
+    throw new Error(
+      `drenv: no dependency named '${name}' in ${project.manifestPath}`,
+    );
+  }
+
+  const existing = await readLock(project.lockPath);
+  const ctx = context(project, log);
+
+  const dependencies: LockedDependency[] = [];
+  for (const spec of manifest.dependencies) {
+    const locked = existing?.dependencies.find((dep) => dep.name === spec.name);
+
+    // Re-resolve the target, and anything not yet locked; reuse the rest.
+    if (spec.name === name || !locked) {
+      dependencies.push(await vendorDependency(spec, ctx));
+    } else {
+      dependencies.push(locked);
+    }
+  }
+
+  const lock: Lockfile = {
+    lockfile_version: LOCKFILE_VERSION,
+    manifest_digest: await fileDigest(project.manifestPath),
+    dependencies,
+  };
+
+  await writeLock(project.lockPath, lock);
+  await writeBundleFile(project.mygame, lock);
+  await ensureVendorIgnore(project.mygame);
+
+  return { lock, needsRequireLine: await needsRequireLine(project) };
+};
+
 const matches = async (
   dir: string,
   integrity: string | undefined,

--- a/utils/sources/git.ts
+++ b/utils/sources/git.ts
@@ -26,6 +26,22 @@ const git = async (
   };
 };
 
+/**
+ * The current upstream commit for a git dependency's tracked ref via
+ * `git ls-remote`. Returns null for pinned commits (not listed as a ref) or
+ * when the remote can't be reached.
+ */
+export const gitRef = async (
+  spec: DependencySpec,
+): Promise<string | null> => {
+  const named = spec.ref ?? spec.tag ?? spec.branch ?? "HEAD";
+  const { ok, stdout } = await git(["ls-remote", spec.git!, named]);
+  if (!ok || !stdout) return null;
+
+  // Each line is "<sha>\t<ref>"; take the first match's sha.
+  return stdout.split("\n")[0]?.split("\t")[0] || null;
+};
+
 export const vendorGit = async (
   spec: DependencySpec,
   ctx: VendorContext,

--- a/utils/sources/github.ts
+++ b/utils/sources/github.ts
@@ -26,6 +26,17 @@ const resolveSha = async (
   }
 };
 
+/** The current upstream commit for a github dependency's requested ref. */
+export const githubRef = async (
+  spec: DependencySpec,
+): Promise<string | null> => {
+  const [owner, repo] = spec.github!.split("/");
+  if (!owner || !repo) return null;
+
+  const requested = spec.ref ?? spec.tag ?? spec.branch ?? "HEAD";
+  return (await resolveSha(owner, repo, requested)) ?? null;
+};
+
 export const vendorGithub = async (
   spec: DependencySpec,
   ctx: VendorContext,

--- a/utils/sources/mod.ts
+++ b/utils/sources/mod.ts
@@ -1,8 +1,8 @@
 import { type DependencySpec, sourceKind } from "../manifest.ts";
 import type { LockedDependency } from "../lockfile.ts";
 
-import { vendorGit } from "./git.ts";
-import { vendorGithub } from "./github.ts";
+import { gitRef, vendorGit } from "./git.ts";
+import { githubRef, vendorGithub } from "./github.ts";
 import { vendorPath } from "./path.ts";
 import { vendorUrl } from "./url.ts";
 
@@ -22,5 +22,20 @@ export const vendorDependency = (
       return vendorGithub(spec, ctx);
     case "git":
       return vendorGit(spec, ctx);
+  }
+};
+
+/**
+ * The current upstream revision for a dependency, for `drenv outdated`. Only
+ * remote, revision-tracked sources have one — `path` and `url` return null.
+ */
+export const remoteRef = (spec: DependencySpec): Promise<string | null> => {
+  switch (sourceKind(spec)) {
+    case "github":
+      return githubRef(spec);
+    case "git":
+      return gitRef(spec);
+    default:
+      return Promise.resolve(null);
   }
 };


### PR DESCRIPTION
Closes the last open item from the command review — the bundler-style dependency workflow (`bundle list` / `update` / `outdated`).

## Commands (Dependency management group)

- **`drenv list`** — declared dependencies with their source and locked short-revision (path deps show `—`).
- **`drenv update [name]`** — re-resolves to the latest allowed revision and rewrites the lock, reporting what moved. With a name, only that dep updates and the rest stay pinned; without one, everything is re-resolved. Fills the "no way to bump a floating `branch` dep short of remove+add" gap.
- **`drenv outdated`** — checks each remote dep's upstream against the lock and lists what's moved on. Path/URL sources are skipped (not revision-tracked).

## Implementation
- `updateDependency` in the bundler re-resolves a single dep and reuses the existing locked entries for the others (resolving any not-yet-locked dep so the lock stays complete).
- `remoteRef` in the sources layer: github via the commits API (`Accept: sha`), git via `git ls-remote`. A pinned `ref`/tag resolves to a stable sha (never "outdated"); a floating branch/HEAD advances.

## Tests
Path-dep (offline) coverage for all three: `list` output, `update` first-resolve / up-to-date / unknown-name, `outdated` up-to-date / no-lockfile. Full suite green (32), `check`/`lint`/`fmt` clean. Live-tested `bundle`/`list`/`outdated`/`update` in a real path-dep project.

Per your call, keep it on **0.11.x** → 0.11.3.