### PR TITLE
Fix Linux DragonRuby installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,6 @@ Run `drenv <command> --help` for flags and details.
 
 ---
 
-Built with [Deno](https://deno.com). Tested on macOS (Apple Silicon) and
-Windows 11 with DragonRuby 5.32, 6.3, 6.4, 6.18, 7.11, and 7.13.
+Built with [Deno](https://deno.com). Tested on macOS (Apple Silicon), SteamOS
+(Linux AMD64), and Windows 11 with DragonRuby 5.32, 6.3, 6.4, 6.18, 7.11, and
+7.13.

--- a/commands/install.test.ts
+++ b/commands/install.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { assertEquals, assertThrows } from "@std/assert";
 
-import { matchesTier } from "./install.ts";
+import { drOrgPlatform, matchesTier } from "./install.ts";
 import { validateTier } from "../utils/tier.ts";
 
 describe("validateTier", () => {
@@ -13,6 +13,16 @@ describe("validateTier", () => {
 
   it("throws on an unknown tier", () => {
     assertThrows(() => validateTier("ultimate"), Error, "unknown tier");
+  });
+});
+
+describe("drOrgPlatform", () => {
+  it("maps Linux ARM64 to the pi endpoint", () => {
+    assertEquals(drOrgPlatform["aarch64-unknown-linux-gnu"], "pi");
+  });
+
+  it("maps Linux x86_64 to the linux endpoint", () => {
+    assertEquals(drOrgPlatform["x86_64-unknown-linux-gnu"], "linux");
   });
 });
 

--- a/commands/install.ts
+++ b/commands/install.ts
@@ -3,6 +3,7 @@ import ora, { type Ora } from "ora";
 
 import register from "./register.ts";
 import { homePath } from "../constants.ts";
+import { makeDrenvTempDir } from "../utils/temp.ts";
 import { type Tier, validateTier } from "../utils/tier.ts";
 
 const DRAGONRUBY_GAME_ID = 404609;
@@ -190,13 +191,15 @@ async function downloadUpload(
   await fileRes.body.pipeTo(file.writable);
 }
 
-// dragonruby.org's platform token, e.g. download_pro_subscription_linux_amd64.
-const drOrgPlatform: Record<string, string> = {
+// dragonruby.org's platform token in download_<tier>_subscription_<token>.
+// Link keys like `pro_linux_amd64` map to `download_*_subscription_linux` — see
+// https://dragonruby.org/api.
+export const drOrgPlatform: Record<string, string> = {
   "x86_64-pc-windows-msvc": "windows",
   "x86_64-apple-darwin": "mac",
   "aarch64-apple-darwin": "mac",
-  "x86_64-unknown-linux-gnu": "linux_amd64",
-  "aarch64-unknown-linux-gnu": "linux_arm64",
+  "x86_64-unknown-linux-gnu": "linux",
+  "aarch64-unknown-linux-gnu": "pi",
 };
 
 /** Downloads the standard tier from itch.io. Returns the register message. */
@@ -220,7 +223,7 @@ async function installFromItch(kv: Deno.Kv, spinner: Ora): Promise<string> {
   const upload = await getUpload(apiKey, downloadKeyId, "standard");
 
   spinner.text = `Downloading ${upload.filename}...`;
-  const tmp = await Deno.makeTempDir({ prefix: "drenv-download-" });
+  const tmp = await makeDrenvTempDir("drenv-download-");
   try {
     const zipPath = `${tmp}/${upload.filename}`;
     await downloadUpload(apiKey, upload.id, downloadKeyId, zipPath);
@@ -294,7 +297,7 @@ async function installFromDragonRubyOrg(
     throw new Error(`drenv: download failed with status ${fileRes.status}`);
   }
 
-  const tmp = await Deno.makeTempDir({ prefix: "drenv-download-" });
+  const tmp = await makeDrenvTempDir("drenv-download-");
   try {
     const destPath = `${tmp}/dragonruby-${tier}-${platform}.zip`;
     const file = await Deno.create(destPath);

--- a/commands/register.ts
+++ b/commands/register.ts
@@ -3,6 +3,7 @@ import { extname, resolve } from "@std/path";
 import { configure, ZipReaderStream } from "@zip-js/zip-js";
 
 import { versionsPath } from "../constants.ts";
+import { makeDrenvTempDir } from "../utils/temp.ts";
 import { versionCommand } from "../utils/version.ts";
 import { validateTier, versionDirName } from "../utils/tier.ts";
 
@@ -19,7 +20,7 @@ export default async function register(
   // up afterward. A directory register moves the given path in place.
   let extractDir: string | undefined;
   if (extname(path) === ".zip") {
-    extractDir = await Deno.makeTempDir({ prefix: "drenv-register-" });
+    extractDir = await makeDrenvTempDir("drenv-register-");
     path = await extractZip(zipOrDirectory, extractDir);
   }
 

--- a/deno.json
+++ b/deno.json
@@ -4,11 +4,11 @@
     "dev": "deno run --watch main.ts",
     "release": "deno run -A scripts/release.ts",
     "compile": "deno compile -A --unstable-kv --output=builds/ main.ts",
-    "compile:windows-x86": "deno compile -A --output=builds/x86_64-pc-windows-msvc.drenv --target=x86_64-pc-windows-msvc main.ts",
-    "compile:macos-x86": "deno compile -A --output=builds/x86_64-apple-darwin.drenv --target=x86_64-apple-darwin main.ts",
-    "compile:macos-arm64": "deno compile -A --output=builds/aarch64-apple-darwin.drenv --target=aarch64-apple-darwin main.ts",
-    "compile:linux-x86": "deno compile -A --output=builds/x86_64-unknown-linux-gnu.drenv --target=x86_64-unknown-linux-gnu main.ts",
-    "compile:linux-arm64": "deno compile -A --output=builds/aarch64-unknown-linux-gnu.drenv --target=aarch64-unknown-linux-gnu main.ts",
+    "compile:windows-x86": "deno compile -A --unstable-kv --output=builds/x86_64-pc-windows-msvc.drenv --target=x86_64-pc-windows-msvc main.ts",
+    "compile:macos-x86": "deno compile -A --unstable-kv --output=builds/x86_64-apple-darwin.drenv --target=x86_64-apple-darwin main.ts",
+    "compile:macos-arm64": "deno compile -A --unstable-kv --output=builds/aarch64-apple-darwin.drenv --target=aarch64-apple-darwin main.ts",
+    "compile:linux-x86": "deno compile -A --unstable-kv --output=builds/x86_64-unknown-linux-gnu.drenv --target=x86_64-unknown-linux-gnu main.ts",
+    "compile:linux-arm64": "deno compile -A --unstable-kv --output=builds/aarch64-unknown-linux-gnu.drenv --target=aarch64-unknown-linux-gnu main.ts",
     "compile:all": "deno task compile:windows-x86 & deno task compile:macos-x86 & deno task compile:macos-arm64 & deno task compile:linux-x86 & deno task compile:linux-arm64"
   },
   "imports": {

--- a/utils/temp.test.ts
+++ b/utils/temp.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "@std/testing/bdd";
+import { assertEquals } from "@std/assert";
+
+import { homePath } from "../constants.ts";
+import { makeDrenvTempDir } from "./temp.ts";
+
+describe("makeDrenvTempDir", () => {
+  it("creates a temp directory under ~/.drenv", async () => {
+    const dir = await makeDrenvTempDir("drenv-test-");
+    try {
+      assertEquals(dir.startsWith(`${homePath}/drenv-test-`), true);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+});

--- a/utils/temp.test.ts
+++ b/utils/temp.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { assertEquals } from "@std/assert";
+import { basename, dirname, normalize } from "@std/path";
 
 import { homePath } from "../constants.ts";
 import { makeDrenvTempDir } from "./temp.ts";
@@ -8,7 +9,8 @@ describe("makeDrenvTempDir", () => {
   it("creates a temp directory under ~/.drenv", async () => {
     const dir = await makeDrenvTempDir("drenv-test-");
     try {
-      assertEquals(dir.startsWith(`${homePath}/drenv-test-`), true);
+      assertEquals(normalize(dirname(dir)), normalize(homePath));
+      assertEquals(basename(dir).startsWith("drenv-test-"), true);
     } finally {
       await Deno.remove(dir, { recursive: true });
     }

--- a/utils/temp.ts
+++ b/utils/temp.ts
@@ -1,0 +1,9 @@
+import { ensureDir } from "@std/fs";
+
+import { homePath } from "../constants.ts";
+
+/** Creates a temp directory under `~/.drenv` (same filesystem as installs). */
+export const makeDrenvTempDir = async (prefix: string): Promise<string> => {
+  await ensureDir(homePath);
+  return await Deno.makeTempDir({ prefix, dir: homePath });
+};


### PR DESCRIPTION
## Summary

- Fix dragonruby.org download endpoints for Linux: AMD64 uses `download_*_subscription_linux`, ARM64 uses `download_*_subscription_pi` (per https://dragonruby.org/api)
- Stage install/register temp directories under `~/.drenv` to avoid cross-device rename failures on SteamOS/Linux
- Add `--unstable-kv` to all platform compile tasks so `Deno.openKv` works in compiled binaries
- Note SteamOS (Linux AMD64) in the README tested platforms list

## Test plan

- [x] `drenv install` (standard tier via itch.io) on SteamOS Linux AMD64
- [x] `drenv install` (pro tier via dragonruby.org) on SteamOS Linux AMD64
- [x] Verified install no longer fails with cross-device rename error