### PR TITLE
feat(deps): vendor library assets via [package] include

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -116,7 +116,17 @@ flags:
 [package]
 root = "lib"                  # only this directory is vendored (default ".")
 entrypoint = "conjuration.rb" # the file to require, relative to root
+include = ["sprites", "data"] # extra paths to vendor (see below)
 ```
 
 Without it, drenv falls back to convention — `lib/<name>.rb`, then `<name>.rb` —
 so many libraries (a `lib/<name>.rb` layout) work with zero configuration.
+
+### Shipping assets (sprites, sounds, data)
+
+`root` scopes vendoring to your code (e.g. `lib/`), so assets that live
+_outside_ it aren't vendored. List them in `include` — paths relative to your
+repo root — and drenv copies each into `vendor/<name>/<path>`, preserving its
+name. A library with `lib/dragon_input.rb` and a top-level `sprites/` would use
+`include = ["sprites"]`, and its sprites land at
+`mygame/vendor/dragon_input/sprites/…` for the game to load.

--- a/utils/manifest.ts
+++ b/utils/manifest.ts
@@ -22,6 +22,12 @@ export type PackageSpec = {
   root?: string;
   /** Entrypoint to require, relative to `root`. */
   entrypoint?: string;
+  /**
+   * Extra paths (files or directories), relative to the repo root, to vendor
+   * alongside the library — e.g. sprites/sounds/data that live outside `root`.
+   * Copied into `vendor/<name>/<path>`, preserving their names.
+   */
+  include?: string[];
 };
 
 export type Manifest = {

--- a/utils/sources/resolve.test.ts
+++ b/utils/sources/resolve.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { assertEquals, assertRejects } from "@std/assert";
-import { ensureDir } from "@std/fs";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { ensureDir, exists } from "@std/fs";
 import { join } from "@std/path";
 
-import { resolveEntrypoint } from "./resolve.ts";
+import { resolveEntrypoint, stageIntoVendor } from "./resolve.ts";
 
 describe("resolveEntrypoint", () => {
   let tmp: string;
@@ -19,7 +19,7 @@ describe("resolveEntrypoint", () => {
   it("uses an explicit override, rooted at the fetched tree", async () => {
     assertEquals(
       await resolveEntrypoint(tmp, "conjuration", "lib/conjuration.rb"),
-      { root: ".", entrypoint: "lib/conjuration.rb" },
+      { root: ".", entrypoint: "lib/conjuration.rb", include: [] },
     );
   });
 
@@ -32,6 +32,7 @@ describe("resolveEntrypoint", () => {
     assertEquals(await resolveEntrypoint(tmp, "conjuration"), {
       root: "lib",
       entrypoint: "conjuration.rb",
+      include: [],
     });
   });
 
@@ -44,6 +45,20 @@ describe("resolveEntrypoint", () => {
     assertEquals(await resolveEntrypoint(tmp, "x"), {
       root: ".",
       entrypoint: "main.rb",
+      include: [],
+    });
+  });
+
+  it("reads [package] include paths", async () => {
+    await Deno.writeTextFile(
+      join(tmp, "drenv.toml"),
+      '[package]\nroot = "lib"\nentrypoint = "x.rb"\ninclude = ["sprites", "data"]\n',
+    );
+
+    assertEquals(await resolveEntrypoint(tmp, "x"), {
+      root: "lib",
+      entrypoint: "x.rb",
+      include: ["sprites", "data"],
     });
   });
 
@@ -54,6 +69,7 @@ describe("resolveEntrypoint", () => {
     assertEquals(await resolveEntrypoint(tmp, "conjuration"), {
       root: "lib",
       entrypoint: "conjuration.rb",
+      include: [],
     });
   });
 
@@ -63,6 +79,7 @@ describe("resolveEntrypoint", () => {
     assertEquals(await resolveEntrypoint(tmp, "draco"), {
       root: ".",
       entrypoint: "draco.rb",
+      include: [],
     });
   });
 
@@ -71,6 +88,86 @@ describe("resolveEntrypoint", () => {
       () => resolveEntrypoint(tmp, "mystery"),
       Error,
       "couldn't determine an entrypoint",
+    );
+  });
+});
+
+describe("stageIntoVendor", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "drenv-stage-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  const ctx = (mygame: string) => ({
+    mygame,
+    manifestDir: mygame,
+    log: () => {},
+  });
+
+  it("vendors declared asset paths alongside the code", async () => {
+    // A library with lib/<name>.rb plus a top-level sprites/ directory.
+    const staging = join(tmp, "lib-src");
+    await ensureDir(join(staging, "lib"));
+    await ensureDir(join(staging, "sprites", "glyphs"));
+    await Deno.writeTextFile(
+      join(staging, "lib", "dragon_input.rb"),
+      "# lib\n",
+    );
+    await Deno.writeTextFile(
+      join(staging, "sprites", "glyphs", "xbox_a.png"),
+      "PNG",
+    );
+    await Deno.writeTextFile(
+      join(staging, "drenv.toml"),
+      '[package]\nroot = "lib"\nentrypoint = "dragon_input.rb"\ninclude = ["sprites"]\n',
+    );
+
+    const mygame = join(tmp, "game", "mygame");
+    await ensureDir(mygame);
+
+    const require = await stageIntoVendor(staging, ctx(mygame), "dragon_input");
+
+    assertEquals(require, "vendor/dragon_input/dragon_input.rb");
+    // Code is vendored (root flattened)...
+    assert(
+      await exists(join(mygame, "vendor", "dragon_input", "dragon_input.rb")),
+    );
+    // ...and so are the declared assets, preserving their path.
+    assert(
+      await exists(
+        join(
+          mygame,
+          "vendor",
+          "dragon_input",
+          "sprites",
+          "glyphs",
+          "xbox_a.png",
+        ),
+      ),
+    );
+  });
+
+  it("rejects an include path that escapes the vendor directory", async () => {
+    const staging = join(tmp, "evil");
+    await ensureDir(join(staging, "lib"));
+    await Deno.writeTextFile(join(staging, "lib", "x.rb"), "");
+    await Deno.writeTextFile(
+      join(staging, "drenv.toml"),
+      '[package]\nroot = "lib"\nentrypoint = "x.rb"\ninclude = ["../secrets"]\n',
+    );
+
+    const mygame = join(tmp, "game", "mygame");
+    await ensureDir(mygame);
+
+    await assertRejects(
+      () => stageIntoVendor(staging, ctx(mygame), "x"),
+      Error,
+      "invalid include path",
     );
   });
 });

--- a/utils/sources/resolve.ts
+++ b/utils/sources/resolve.ts
@@ -47,19 +47,23 @@ export const resolveEntrypoint = async (
   staging: string,
   name: string,
   override?: string,
-): Promise<{ root: string; entrypoint: string }> => {
-  if (override) return { root: ".", entrypoint: override };
-
+): Promise<{ root: string; entrypoint: string; include: string[] }> => {
+  // A library declares its asset paths in `[package].include`, regardless of how
+  // the entrypoint itself resolves.
   const pkg = await readPackage(staging);
+  const include = pkg?.include ?? [];
+
+  if (override) return { root: ".", entrypoint: override, include };
+
   if (pkg?.entrypoint) {
-    return { root: pkg.root ?? ".", entrypoint: pkg.entrypoint };
+    return { root: pkg.root ?? ".", entrypoint: pkg.entrypoint, include };
   }
 
   if (await exists(join(staging, "lib", `${name}.rb`))) {
-    return { root: "lib", entrypoint: `${name}.rb` };
+    return { root: "lib", entrypoint: `${name}.rb`, include };
   }
   if (await exists(join(staging, `${name}.rb`))) {
-    return { root: ".", entrypoint: `${name}.rb` };
+    return { root: ".", entrypoint: `${name}.rb`, include };
   }
 
   throw new Error(
@@ -78,7 +82,11 @@ export const stageIntoVendor = async (
   name: string,
   override?: string,
 ): Promise<string> => {
-  const { root, entrypoint } = await resolveEntrypoint(staging, name, override);
+  const { root, entrypoint, include } = await resolveEntrypoint(
+    staging,
+    name,
+    override,
+  );
 
   const source = root === "." ? staging : join(staging, root);
   if (!await exists(source)) {
@@ -90,6 +98,24 @@ export const stageIntoVendor = async (
   const dest = vendorDir(ctx, name);
   await Deno.remove(dest, { recursive: true }).catch(() => {});
   await copyTree(source, dest);
+
+  // Vendor any declared asset paths (repo-root-relative) alongside the code, so
+  // libraries can ship sprites/sounds/data that live outside `root`.
+  for (const rel of include) {
+    if (rel.startsWith("/") || rel.split(/[\\/]/).includes("..")) {
+      throw new Error(
+        `drenv: invalid include path '${rel}' in dependency '${name}' (must be relative, no '..')`,
+      );
+    }
+
+    const from = join(staging, rel);
+    if (!await exists(from)) {
+      throw new Error(
+        `drenv: include path '${rel}' not found in dependency '${name}'`,
+      );
+    }
+    await copyTree(from, join(dest, rel));
+  }
 
   if (!await exists(join(dest, entrypoint))) {
     throw new Error(

--- a/utils/version.test.ts
+++ b/utils/version.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertEquals, assertRejects } from "@std/assert";
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
 
 import { dragonrubyBinary, versionCommand } from "./version.ts";
 
@@ -38,7 +37,7 @@ describe("versionCommand", () => {
 
     await Deno.writeTextFile(
       binary,
-      '#!/bin/sh\necho 7.11',
+      "#!/bin/sh\necho 7.11",
     );
     await Deno.chmod(binary, 0o755);
 


### PR DESCRIPTION
`drenv` vendored a library's **code** but dropped its **assets**. `resolveEntrypoint` scopes vendoring to the package `root` (e.g. `lib/`), and `copyTree` copies everything under it — but a DragonRuby library keeps sprites/sounds/data in top-level dirs *outside* `lib/`, so they never made it into `vendor/`. (Hit while building `dragon_input`, which ships glyph PNGs.)

## Fix
A library declares its non-code paths in `[package].include`:

```toml
[package]
root = "lib"
entrypoint = "dragon_input.rb"
include = ["sprites", "data"]   # repo-root-relative
```

Each is copied into `vendor/<name>/<path>` (preserving its name) alongside the flattened code root. So `sprites/glyphs/xbox_a.png` lands at `mygame/vendor/dragon_input/sprites/glyphs/xbox_a.png` for the game to load.

- Backward compatible — no `include`, no change. `root`/entrypoint semantics untouched.
- Include paths are validated to stay inside the vendor dir (rejects absolute paths and `..`).
- `include` is honored however the entrypoint resolves (explicit `[package]` or the `lib/<name>.rb` convention).

## Tests
`resolveEntrypoint` parses `include`; `stageIntoVendor` vendors the assets and rejects an escaping path. Verified live: bundling a path dep with `include = ["sprites"]` produces both `vendor/dragon_input/dragon_input.rb` and `vendor/dragon_input/sprites/glyphs/xbox_a.png`. 37 tests pass; `check`/`lint`/`fmt` clean.

New capability, backward compatible.