### PR TITLE
feat: add drenv build (dragonruby-publish --only-package)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Run `drenv <command> --help` for flags and details.
 | `use [version]`   | Switch the current project's version           |
 | `version`         | Print the current project's version            |
 | `run [args...]`   | Vendor dependencies and launch the game        |
+| `build [args…]`   | Package locally (`dragonruby-publish` only)    |
 | `publish [args…]` | Verify dependencies, then `dragonruby-publish` |
 
 **Dependency management**

--- a/commands/build.test.ts
+++ b/commands/build.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertRejects, assertStringIncludes } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+import build from "./build.ts";
+
+describe("build", () => {
+  let cwd: string;
+  let tmp: string;
+  let root: string;
+
+  beforeEach(async () => {
+    cwd = Deno.cwd();
+    tmp = await Deno.makeTempDir({ prefix: "drenv-build-" });
+    root = join(tmp, "game");
+    await ensureDir(join(root, "mygame", "app"));
+    Deno.chdir(root);
+  });
+
+  afterEach(async () => {
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("rejects when dragonruby-publish is missing", async () => {
+    await assertRejects(
+      () => build(),
+      Error,
+      "dragonruby-publish binary not found",
+    );
+  });
+
+  it("runs dragonruby-publish with --only-package and the game dir", async () => {
+    if (Deno.build.os === "windows") return; // uses a unix shell shim
+
+    const binary = join(root, "dragonruby-publish");
+    await Deno.writeTextFile(binary, '#!/bin/sh\necho "$@" > args.txt\n');
+    await Deno.chmod(binary, 0o755);
+
+    await build(["--verbose"]);
+
+    const args = await Deno.readTextFile(join(root, "args.txt"));
+    assertStringIncludes(args, "--only-package");
+    assertStringIncludes(args, "--verbose");
+    assertStringIncludes(args, "mygame");
+  });
+});

--- a/commands/build.ts
+++ b/commands/build.ts
@@ -1,0 +1,6 @@
+import { runDragonrubyPublish } from "../utils/dragonruby-publish.ts";
+
+/** Packages the project locally with `dragonruby-publish --only-package`. */
+export default function build(forwarded: string[] = []): Promise<void> {
+  return runDragonrubyPublish(["--only-package", ...forwarded]);
+}

--- a/commands/publish.ts
+++ b/commands/publish.ts
@@ -1,49 +1,6 @@
-import { exists } from "@std/fs";
-import { join } from "@std/path";
+import { runDragonrubyPublish } from "../utils/dragonruby-publish.ts";
 
-import { findProject } from "../utils/project.ts";
-import { reconcile } from "../utils/bundler.ts";
-import { BUNDLE_REQUIRE } from "../utils/bundle-file.ts";
-
-export default async function publish(forwarded: string[] = []) {
-  const project = await findProject();
-
-  // Verify dependencies against the lockfile and vendor them into the package.
-  // Frozen so a publish always ships exactly what's locked.
-  if (await exists(project.manifestPath)) {
-    const { lock, needsRequireLine } = await reconcile(project, {
-      log: (message) => console.log(message),
-      frozen: true,
-    });
-
-    if (needsRequireLine && lock.dependencies.length > 0) {
-      console.log(
-        `drenv: warning — mygame/app/main.rb does not require the bundle.\n  Add: ${BUNDLE_REQUIRE}`,
-      );
-    }
-  }
-
-  const binary = join(
-    project.root,
-    Deno.build.os === "windows"
-      ? "dragonruby-publish.exe"
-      : "dragonruby-publish",
-  );
-
-  if (!await exists(binary)) {
-    throw new Error(`drenv: dragonruby-publish binary not found at ${binary}`);
-  }
-
-  // dragonruby-publish takes the game directory last: [flags...] GAME_DIRECTORY
-  const { code } = await new Deno.Command(binary, {
-    args: [...forwarded, "mygame"],
-    cwd: project.root,
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
-  }).output();
-
-  if (code !== 0) {
-    Deno.exit(code);
-  }
+/** Verifies dependencies against the lockfile, then publishes with dragonruby-publish. */
+export default function publish(forwarded: string[] = []): Promise<void> {
+  return runDragonrubyPublish(forwarded);
 }

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -99,12 +99,18 @@ changes hot-reload into the running game — handy when developing a library
 alongside it. Pass `--no-watch` to turn that off (`--frozen` skips it too).
 Extra arguments are forwarded to the `dragonruby` binary.
 
+### `drenv build [args...]`
+
+Packages the project locally without publishing — verifies dependencies against
+the lockfile (like `--frozen`), then runs `dragonruby-publish --only-package` on
+`mygame`, producing the platform packages in `builds/`. Extra arguments are
+forwarded. Handy in CI or for testing a packaged build.
+
 ### `drenv publish [args...]`
 
 Verifies dependencies against the lockfile (like `--frozen`), then runs
-`dragonruby-publish` on `mygame`, forwarding any arguments. `drenv publish`
-ships to itch.io and `drenv publish --package` packages locally — always
-shipping exactly what's locked.
+`dragonruby-publish` on `mygame`, forwarding any arguments — always shipping
+exactly what's locked. Use `drenv build` when you only want the local packages.
 
 ## Publishing a library
 

--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,7 @@ import install from "./commands/install.ts";
 import use from "./commands/use.ts";
 import version from "./commands/version.ts";
 import newCommand from "./commands/new.ts";
+import build from "./commands/build.ts";
 import publish from "./commands/publish.ts";
 import register from "./commands/register.ts";
 import uninstall from "./commands/uninstall.ts";
@@ -168,6 +169,16 @@ program
   .description("Sync dependencies and launch the project with DragonRuby")
   .helpGroup(PROJECT)
   .action(actionRunner(run, { skipUpdateCheck: true }));
+
+program
+  .command("build")
+  .argument("[args...]", "Arguments forwarded to dragonruby-publish")
+  .allowUnknownOption()
+  .description(
+    "Package the project locally (dragonruby-publish --only-package)",
+  )
+  .helpGroup(PROJECT)
+  .action(actionRunner(build, { skipUpdateCheck: true }));
 
 program
   .command("publish")

--- a/utils/dragonruby-publish.ts
+++ b/utils/dragonruby-publish.ts
@@ -1,0 +1,57 @@
+import { exists } from "@std/fs";
+import { join } from "@std/path";
+
+import { findProject } from "./project.ts";
+import { reconcile } from "./bundler.ts";
+import { BUNDLE_REQUIRE } from "./bundle-file.ts";
+
+/**
+ * Reconciles dependencies against the lockfile (frozen), then runs the project's
+ * `dragonruby-publish` binary with `flags`, appending the game directory last.
+ * Shared by `drenv publish` (ships) and `drenv build` (`--only-package`). Exits
+ * with dragonruby-publish's code on failure.
+ */
+export const runDragonrubyPublish = async (
+  flags: string[],
+): Promise<void> => {
+  const project = await findProject();
+
+  // Verify dependencies against the lockfile and vendor them into the package,
+  // frozen so the artifact contains exactly what's locked.
+  if (await exists(project.manifestPath)) {
+    const { lock, needsRequireLine } = await reconcile(project, {
+      log: (message) => console.log(message),
+      frozen: true,
+    });
+
+    if (needsRequireLine && lock.dependencies.length > 0) {
+      console.log(
+        `drenv: warning — mygame/app/main.rb does not require the bundle.\n  Add: ${BUNDLE_REQUIRE}`,
+      );
+    }
+  }
+
+  const binary = join(
+    project.root,
+    Deno.build.os === "windows"
+      ? "dragonruby-publish.exe"
+      : "dragonruby-publish",
+  );
+
+  if (!await exists(binary)) {
+    throw new Error(`drenv: dragonruby-publish binary not found at ${binary}`);
+  }
+
+  // dragonruby-publish takes the game directory last: [flags...] GAME_DIRECTORY
+  const { code } = await new Deno.Command(binary, {
+    args: [...flags, "mygame"],
+    cwd: project.root,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  }).output();
+
+  if (code !== 0) {
+    Deno.exit(code);
+  }
+};


### PR DESCRIPTION
Adds **`drenv build [args...]`** — package the project locally without publishing.

It mirrors `drenv publish` but stops at packaging: verify dependencies against the lockfile (frozen), then run **`dragonruby-publish --only-package`** on `mygame`, producing the platform packages in `builds/`. Extra arguments are forwarded — useful in CI or to test a packaged build.

## Implementation
- Extracted the shared reconcile + `dragonruby-publish` runner into `utils/dragonruby-publish.ts`. `publish` and `build` both call it; `build` just prepends `--only-package`.
- Registered under **Project management** in the help, between `run` and `publish`.

> Note: the real DragonRuby flag is `--only-package` (per the itch wizard), not `--package-only`.

## Tests
`build` rejects when the `dragonruby-publish` binary is missing, and (via a shell shim) invokes it with `--only-package … mygame`. Full suite: 39 passing; `check`/`lint`/`fmt` clean. Docs updated (README table + `docs/dependencies.md`).