### PR TITLE
fix: adding a dependency no longer re-resolves existing locked refs

### DIFF
--- a/commands/add.test.ts
+++ b/commands/add.test.ts
@@ -58,7 +58,9 @@ describe("add (sticky lock)", () => {
     await ensureDir(join(mygame, "app"));
     await Deno.writeTextFile(
       join(mygame, "drenv.toml"),
-      `[dependencies.frame_timer]\ngit = "${repo}"\n`,
+      // Forward slashes: backslashes are escape characters in TOML strings,
+      // and git accepts forward-slash paths on Windows too.
+      `[dependencies.frame_timer]\ngit = "${repo.replaceAll("\\", "/")}"\n`,
     );
     await Deno.writeTextFile(
       join(mygame, "app", "main.rb"),

--- a/commands/add.test.ts
+++ b/commands/add.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+import add from "./add.ts";
+import { bundle } from "../utils/bundler.ts";
+import { readLock } from "../utils/lockfile.ts";
+import type { Project } from "../utils/project.ts";
+
+const git = async (args: string[], cwd: string) => {
+  const { success, stderr } = await new Deno.Command("git", {
+    args: [
+      // Isolate from the developer's global config so commits work anywhere.
+      "-c",
+      "user.name=drenv-test",
+      "-c",
+      "user.email=test@drenv.test",
+      "-c",
+      "commit.gpgsign=false",
+      ...args,
+    ],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  if (!success) {
+    throw new Error(
+      `git ${args.join(" ")}: ${new TextDecoder().decode(stderr)}`,
+    );
+  }
+};
+
+describe("add (sticky lock)", () => {
+  let cwd: string;
+  let tmp: string;
+  let project: Project;
+  let repo: string;
+
+  beforeEach(async () => {
+    cwd = Deno.cwd();
+    tmp = await Deno.makeTempDir({ prefix: "drenv-add-" });
+
+    // A local git repo standing in for an unpinned remote dep (tracks HEAD).
+    repo = join(tmp, "frame-timer");
+    await ensureDir(join(repo, "lib"));
+    await Deno.writeTextFile(join(repo, "lib", "frame_timer.rb"), "# v1\n");
+    await git(["init", "-b", "main"], repo);
+    await git(["add", "."], repo);
+    await git(["commit", "-m", "v1"], repo);
+
+    // A second, path-sourced library to add later.
+    await ensureDir(join(tmp, "other", "lib"));
+    await Deno.writeTextFile(join(tmp, "other", "lib", "other.rb"), "# lib\n");
+
+    const mygame = join(tmp, "game", "mygame");
+    await ensureDir(join(mygame, "app"));
+    await Deno.writeTextFile(
+      join(mygame, "drenv.toml"),
+      `[dependencies.frame_timer]\ngit = "${repo}"\n`,
+    );
+    await Deno.writeTextFile(
+      join(mygame, "app", "main.rb"),
+      "def tick args\nend\n",
+    );
+
+    project = {
+      root: join(tmp, "game"),
+      mygame,
+      manifestPath: join(mygame, "drenv.toml"),
+      lockPath: join(mygame, "drenv.lock"),
+    };
+    Deno.chdir(project.root);
+  });
+
+  afterEach(async () => {
+    Deno.chdir(cwd);
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("does not move existing locked refs when adding a dependency", async () => {
+    await bundle(project);
+    const before = await readLock(project.lockPath);
+    const lockedRef = before?.dependencies.find((d) => d.name === "frame_timer")
+      ?.ref;
+    assertExists(lockedRef);
+
+    // Upstream moves on after we locked.
+    await Deno.writeTextFile(join(repo, "lib", "frame_timer.rb"), "# v2\n");
+    await git(["add", "."], repo);
+    await git(["commit", "-m", "v2"], repo);
+
+    await add(`path:${join(tmp, "other")}`);
+
+    const after = await readLock(project.lockPath);
+    assertEquals(
+      after?.dependencies.find((d) => d.name === "frame_timer")?.ref,
+      lockedRef,
+      "adding a dependency must not re-resolve existing locked refs",
+    );
+    assert(after?.dependencies.some((d) => d.name === "other"));
+  });
+});

--- a/commands/add.ts
+++ b/commands/add.ts
@@ -48,7 +48,9 @@ export default async function add(source: string, options: AddOptions = {}) {
       name ??= basename(absolute).replace(/\.[^.]+$/, "");
     }
 
-    value = relative(project.mygame, directory) || ".";
+    // Store with forward slashes: backslashes are escape characters in TOML
+    // strings, and the manifest is committed and shared across platforms.
+    value = (relative(project.mygame, directory) || ".").replaceAll("\\", "/");
   }
 
   name ??= deriveName({ kind: parsed.kind, value });

--- a/commands/add.ts
+++ b/commands/add.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, relative, resolve } from "@std/path";
 
 import { findProject } from "../utils/project.ts";
-import { bundle } from "../utils/bundler.ts";
+import { updateDependency } from "../utils/bundler.ts";
 import { BUNDLE_REQUIRE } from "../utils/bundle-file.ts";
 import { type DependencySpec, readManifest } from "../utils/manifest.ts";
 import {
@@ -76,7 +76,9 @@ export default async function add(source: string, options: AddOptions = {}) {
 
   let needsRequireLine: boolean;
   try {
-    ({ needsRequireLine } = await bundle(project, {
+    // Resolve only the new dependency; existing locked refs stay put. Locked
+    // refs move only under `drenv update`.
+    ({ needsRequireLine } = await updateDependency(project, name, {
       log: (message) => console.log(message),
     }));
   } catch (error) {

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -52,6 +52,9 @@ Pass `-e, --entrypoint` only when the library doesn't declare or follow a
 conventional entrypoint, `-n, --name` to override the derived name, and
 `--tag`/`--branch`/`--ref` to pin a `github`/`git` revision.
 
+Adding resolves **only the new dependency** — everything else stays at its
+locked revision. Locked refs move only under `drenv update`.
+
 ### `drenv remove <name>`
 
 Removes a dependency from `mygame/drenv.toml`, deletes its vendored copy, and


### PR DESCRIPTION
Fixes the lockfile-churn incident: while adding a package, drenv re-resolved and silently refreshed an unpinned github dep to latest HEAD, which had to be hand-reverted.

## Cause
`add` called `bundle()`, which is documented as "resolves every dependency from scratch" — so any unpinned dep (branch-tracking or HEAD-tracking) moved as a side effect of adding something unrelated.

## Fix
`add` now uses `updateDependency`'s conservative path: **resolve only the new dependency; reuse locked entries for everything else.** (`remove` already behaved this way.)

Principle now documented in `docs/dependencies.md`: **locked refs move only under `drenv update`** — never as a side effect of `add`.

Bonus: an unreachable *existing* remote no longer fails an unrelated `add`.

## Tests
New regression test stands up a local git repo as an unpinned dep, locks it, advances upstream HEAD, then `add`s a second dep — asserting the locked ref did not move. **Verified it fails against the old `add`** and passes with the fix. Full suite: 41 passing.

## Residual (out of scope, noted for the nested-deps work)
`reconcile`'s fallback still full-re-resolves when the manifest digest changes (hand-editing `drenv.toml` then `drenv run`). Fixing that needs spec-aware diffing (the lock doesn't record pins today) — planned as part of the nested-dependency lockfile rework.

Bug fix → patch (0.14.2), or rides along with the nested-deps minor.