### PR TITLE
feat: nested (transitive) dependencies

### DIFF
--- a/commands/list.ts
+++ b/commands/list.ts
@@ -46,7 +46,20 @@ export default async function list() {
     ref: shortRef(
       lock?.dependencies.find((dep) => dep.name === spec.name)?.ref,
     ),
+    via: "",
   }));
+
+  // Transitive dependencies live only in the lock; annotate their parents.
+  for (const dep of lock?.dependencies ?? []) {
+    if (dep.via?.length && !rows.some((row) => row.name === dep.name)) {
+      rows.push({
+        name: dep.name,
+        source: dep.source,
+        ref: shortRef(dep.ref),
+        via: `via ${dep.via.join(", ")}`,
+      });
+    }
+  }
 
   const nameWidth = Math.max(...rows.map((row) => row.name.length));
   const sourceWidth = Math.max(...rows.map((row) => row.source.length));
@@ -55,7 +68,7 @@ export default async function list() {
     console.log(
       `  ${row.name.padEnd(nameWidth)}  ${
         row.source.padEnd(sourceWidth)
-      }  ${row.ref}`,
+      }  ${row.ref}${row.via ? `  ${row.via}` : ""}`,
     );
   }
 }

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -139,3 +139,39 @@ repo root — and drenv copies each into `vendor/<name>/<path>`, preserving its
 name. A library with `lib/dragon_input.rb` and a top-level `sprites/` would use
 `include = ["sprites"]`, and its sprites land at
 `mygame/vendor/dragon_input/sprites/…` for the game to load.
+
+### Declaring dependencies (nested dependencies)
+
+A library can depend on other libraries. Declare them in the same
+`[dependencies]` table games use, in the `drenv.toml` at your repo root:
+
+```toml
+[package]
+root = "lib"
+entrypoint = "conjuration.rb"
+
+[dependencies.dragon_input]
+github = "Nitemaeric/dragon_input"
+```
+
+When a game vendors your library, drenv resolves your dependencies too — flat,
+one copy per package under `mygame/vendor/<name>`, required before your library
+in the generated bundle. The game's lockfile records the whole graph, and
+`drenv list` shows transitive deps as `via <parent>`.
+
+**Conflict policy.** Each package name resolves to exactly one spec:
+
+- If the **game** declares the package in its own `drenv.toml`, that spec wins —
+  drenv warns when a library wanted something different.
+- If two **libraries** declare the same package with different specs, that's an
+  error; the game resolves it by declaring the package top-level.
+
+**Rules for library-declared dependencies:**
+
+- `path:` dependencies are only allowed when your library is itself consumed as
+  a `path:` dependency (local, side-by-side development) — a relative path
+  inside a remote library points at nothing on the consumer's machine.
+- Dependency cycles are an error.
+- Locked refs stay sticky: updating one package never silently moves another's
+  locked revision. `drenv update <parent>` re-resolves the parent and anything
+  it newly declares; packages it dropped are pruned.

--- a/utils/bundler-nested.test.ts
+++ b/utils/bundler-nested.test.ts
@@ -358,13 +358,12 @@ describe("bundler (nested dependencies)", () => {
 
     await reconcile(project);
 
-    // Restored at the locked revision, not upstream HEAD.
-    assertEquals(
-      await Deno.readTextFile(
-        join(project.mygame, "vendor", "timer", "timer.rb"),
-      ),
-      "# timer\n",
+    // Restored at the locked revision, not upstream HEAD. Normalize line
+    // endings: git's autocrlf checks files out with \r\n on Windows runners.
+    const restored = await Deno.readTextFile(
+      join(project.mygame, "vendor", "timer", "timer.rb"),
     );
+    assertEquals(restored.replaceAll("\r\n", "\n"), "# timer\n");
   });
 
   it("drops orphaned packages when a parent stops depending on them", async () => {

--- a/utils/bundler-nested.test.ts
+++ b/utils/bundler-nested.test.ts
@@ -1,0 +1,432 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { ensureDir, exists } from "@std/fs";
+import { join } from "@std/path";
+
+import { bundle, reconcile, updateDependency } from "./bundler.ts";
+import { readLock } from "./lockfile.ts";
+import type { Project } from "./project.ts";
+
+const git = async (args: string[], cwd: string) => {
+  const { success, stderr } = await new Deno.Command("git", {
+    args: [
+      "-c",
+      "user.name=drenv-test",
+      "-c",
+      "user.email=test@drenv.test",
+      "-c",
+      "commit.gpgsign=false",
+      ...args,
+    ],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  if (!success) {
+    throw new Error(
+      `git ${args.join(" ")}: ${new TextDecoder().decode(stderr)}`,
+    );
+  }
+};
+
+/** A library at <tmp>/<name> with lib/<name>.rb and an optional drenv.toml. */
+const makeLib = async (
+  tmp: string,
+  name: string,
+  manifest?: string,
+  content = `# ${name}\n`,
+) => {
+  const dir = join(tmp, name);
+  await ensureDir(join(dir, "lib"));
+  await Deno.writeTextFile(join(dir, "lib", `${name}.rb`), content);
+  if (manifest) {
+    await Deno.writeTextFile(join(dir, "drenv.toml"), manifest);
+  }
+  return dir;
+};
+
+const makeGame = async (tmp: string, manifest: string): Promise<Project> => {
+  const mygame = join(tmp, "game", "mygame");
+  await ensureDir(join(mygame, "app"));
+  await Deno.writeTextFile(join(mygame, "drenv.toml"), manifest);
+  await Deno.writeTextFile(
+    join(mygame, "app", "main.rb"),
+    "def tick args\nend\n",
+  );
+
+  return {
+    root: join(tmp, "game"),
+    mygame,
+    manifestPath: join(mygame, "drenv.toml"),
+    lockPath: join(mygame, "drenv.lock"),
+  };
+};
+
+describe("bundler (nested dependencies)", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "drenv-nested-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("resolves a transitive path dep flat, with via and require order", async () => {
+    // dragon_input ships an asset dir via include; conjuration depends on it.
+    const diDir = join(tmp, "dragon_input");
+    await ensureDir(join(diDir, "lib"));
+    await ensureDir(join(diDir, "sprites"));
+    await Deno.writeTextFile(join(diDir, "lib", "dragon_input.rb"), "# di\n");
+    await Deno.writeTextFile(join(diDir, "sprites", "a.png"), "PNG");
+    await Deno.writeTextFile(
+      join(diDir, "drenv.toml"),
+      '[package]\nroot = "lib"\nentrypoint = "dragon_input.rb"\ninclude = ["sprites"]\n',
+    );
+
+    await makeLib(
+      tmp,
+      "conjuration",
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
+        '[dependencies.dragon_input]\npath = "../dragon_input"\n',
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n',
+    );
+
+    await bundle(project);
+
+    // Both vendored flat, transitive include assets flowing through.
+    assert(
+      await exists(
+        join(project.mygame, "vendor", "conjuration", "conjuration.rb"),
+      ),
+    );
+    assert(
+      await exists(
+        join(project.mygame, "vendor", "dragon_input", "dragon_input.rb"),
+      ),
+    );
+    assert(
+      await exists(
+        join(project.mygame, "vendor", "dragon_input", "sprites", "a.png"),
+      ),
+    );
+
+    // The lock records the graph edge.
+    const lock = await readLock(project.lockPath);
+    const di = lock?.dependencies.find((d) => d.name === "dragon_input");
+    assertEquals(di?.via, ["conjuration"]);
+    assertEquals(
+      lock?.dependencies.find((d) => d.name === "conjuration")?.via,
+      undefined,
+    );
+
+    // Dependencies are required before their dependents.
+    const bundleFile = await Deno.readTextFile(
+      join(project.mygame, "app", "drenv_bundle.rb"),
+    );
+    assert(
+      bundleFile.indexOf("vendor/dragon_input/") <
+        bundleFile.indexOf("vendor/conjuration/"),
+      "dragon_input must be required before conjuration",
+    );
+  });
+
+  it("prefers the game's top-level spec over a transitive one", async () => {
+    await makeLib(tmp, "dragon_input", undefined, "# upstream\n");
+    await makeLib(tmp, "dragon_input_alt", undefined, "# mine\n");
+    // The alt library still exposes the dragon_input entrypoint name.
+    await Deno.writeTextFile(
+      join(tmp, "dragon_input_alt", "lib", "dragon_input.rb"),
+      "# mine\n",
+    );
+    await makeLib(
+      tmp,
+      "conjuration",
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
+        '[dependencies.dragon_input]\npath = "../dragon_input"\n',
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n\n' +
+        '[dependencies.dragon_input]\npath = "../../dragon_input_alt"\n',
+    );
+
+    await bundle(project);
+
+    assertEquals(
+      await Deno.readTextFile(
+        join(project.mygame, "vendor", "dragon_input", "dragon_input.rb"),
+      ),
+      "# mine\n",
+    );
+  });
+
+  it("rejects conflicting transitive specs without a top-level arbiter", async () => {
+    await makeLib(tmp, "shared1");
+    await makeLib(tmp, "shared2");
+    await Deno.writeTextFile(
+      join(tmp, "shared1", "lib", "shared.rb"),
+      "# one\n",
+    );
+    await Deno.writeTextFile(
+      join(tmp, "shared2", "lib", "shared.rb"),
+      "# two\n",
+    );
+    await makeLib(
+      tmp,
+      "parent_a",
+      '[package]\nroot = "lib"\nentrypoint = "parent_a.rb"\n\n' +
+        '[dependencies.shared]\npath = "../shared1"\n',
+    );
+    await makeLib(
+      tmp,
+      "parent_b",
+      '[package]\nroot = "lib"\nentrypoint = "parent_b.rb"\n\n' +
+        '[dependencies.shared]\npath = "../shared2"\n',
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.parent_a]\npath = "../../parent_a"\n\n' +
+        '[dependencies.parent_b]\npath = "../../parent_b"\n',
+    );
+
+    await assertRejects(
+      () => bundle(project),
+      Error,
+      "conflicting specs for 'shared'",
+    );
+  });
+
+  it("rejects a path dependency declared by a remote source", async () => {
+    const repo = await makeLib(
+      tmp,
+      "remote_parent",
+      '[package]\nroot = "lib"\nentrypoint = "remote_parent.rb"\n\n' +
+        '[dependencies.local_helper]\npath = "../helper"\n',
+    );
+    await git(["init", "-b", "main"], repo);
+    await git(["add", "."], repo);
+    await git(["commit", "-m", "v1"], repo);
+
+    const project = await makeGame(
+      tmp,
+      `[dependencies.remote_parent]\ngit = "${repo.replaceAll("\\", "/")}"\n`,
+    );
+
+    await assertRejects(
+      () => bundle(project),
+      Error,
+      "can't be transitive from remote sources",
+    );
+  });
+
+  it("rejects dependency cycles", async () => {
+    await makeLib(
+      tmp,
+      "lib_a",
+      '[package]\nroot = "lib"\nentrypoint = "lib_a.rb"\n\n' +
+        '[dependencies.lib_b]\npath = "../lib_b"\n',
+    );
+    await makeLib(
+      tmp,
+      "lib_b",
+      '[package]\nroot = "lib"\nentrypoint = "lib_b.rb"\n\n' +
+        '[dependencies.lib_a]\npath = "../lib_a"\n',
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.lib_a]\npath = "../../lib_a"\n',
+    );
+
+    await assertRejects(() => bundle(project), Error, "dependency cycle");
+  });
+
+  it("keeps a locked transitive ref when updating an unrelated dep", async () => {
+    // timer: a git repo standing in for an unpinned remote transitive dep.
+    const timer = await makeLib(tmp, "timer");
+    await git(["init", "-b", "main"], timer);
+    await git(["add", "."], timer);
+    await git(["commit", "-m", "v1"], timer);
+
+    await makeLib(
+      tmp,
+      "conjuration",
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
+        `[dependencies.timer]\ngit = "${timer.replaceAll("\\", "/")}"\n`,
+    );
+    await makeLib(tmp, "other");
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n\n' +
+        '[dependencies.other]\npath = "../../other"\n',
+    );
+
+    await bundle(project);
+    const lockedRef = (await readLock(project.lockPath))?.dependencies.find(
+      (d) => d.name === "timer",
+    )?.ref;
+    assertExists(lockedRef);
+
+    // Upstream moves on after we locked.
+    await Deno.writeTextFile(join(timer, "lib", "timer.rb"), "# v2\n");
+    await git(["add", "."], timer);
+    await git(["commit", "-m", "v2"], timer);
+
+    // Updating an unrelated dep must not move the transitive ref...
+    await updateDependency(project, "other");
+    assertEquals(
+      (await readLock(project.lockPath))?.dependencies.find(
+        (d) => d.name === "timer",
+      )?.ref,
+      lockedRef,
+    );
+
+    // ...and neither must updating its parent (spec unchanged = reuse).
+    await updateDependency(project, "conjuration");
+    assertEquals(
+      (await readLock(project.lockPath))?.dependencies.find(
+        (d) => d.name === "timer",
+      )?.ref,
+      lockedRef,
+    );
+  });
+
+  it("names the parents when updating a transitive dep directly", async () => {
+    await makeLib(tmp, "dragon_input");
+    await makeLib(
+      tmp,
+      "conjuration",
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
+        '[dependencies.dragon_input]\npath = "../dragon_input"\n',
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n',
+    );
+    await bundle(project);
+
+    await assertRejects(
+      () => updateDependency(project, "dragon_input"),
+      Error,
+      "via conjuration",
+    );
+  });
+
+  it("restores a missing transitive vendor dir from the lock on reconcile", async () => {
+    const timer = await makeLib(tmp, "timer");
+    await git(["init", "-b", "main"], timer);
+    await git(["add", "."], timer);
+    await git(["commit", "-m", "v1"], timer);
+
+    await makeLib(
+      tmp,
+      "conjuration",
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
+        `[dependencies.timer]\ngit = "${timer.replaceAll("\\", "/")}"\n`,
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n',
+    );
+    await bundle(project);
+
+    // Upstream advances, then the vendored copy goes missing (fresh clone).
+    await Deno.writeTextFile(join(timer, "lib", "timer.rb"), "# v2\n");
+    await git(["add", "."], timer);
+    await git(["commit", "-m", "v2"], timer);
+    await Deno.remove(join(project.mygame, "vendor", "timer"), {
+      recursive: true,
+    });
+
+    await reconcile(project);
+
+    // Restored at the locked revision, not upstream HEAD.
+    assertEquals(
+      await Deno.readTextFile(
+        join(project.mygame, "vendor", "timer", "timer.rb"),
+      ),
+      "# timer\n",
+    );
+  });
+
+  it("drops orphaned packages when a parent stops depending on them", async () => {
+    await makeLib(tmp, "dragon_input");
+    const conjDir = await makeLib(
+      tmp,
+      "conjuration",
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
+        '[dependencies.dragon_input]\npath = "../dragon_input"\n',
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n',
+    );
+    await bundle(project);
+    assert(await exists(join(project.mygame, "vendor", "dragon_input")));
+
+    // Conjuration drops the dependency; updating it prunes the orphan.
+    await Deno.writeTextFile(
+      join(conjDir, "drenv.toml"),
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n',
+    );
+    await updateDependency(project, "conjuration");
+
+    const lock = await readLock(project.lockPath);
+    assertEquals(
+      lock?.dependencies.some((d) => d.name === "dragon_input"),
+      false,
+    );
+    assertEquals(
+      await exists(join(project.mygame, "vendor", "dragon_input")),
+      false,
+    );
+  });
+
+  it("surfaces the top-level override in the log", async () => {
+    await makeLib(tmp, "dragon_input");
+    await makeLib(tmp, "dragon_input_alt");
+    await Deno.writeTextFile(
+      join(tmp, "dragon_input_alt", "lib", "dragon_input.rb"),
+      "# mine\n",
+    );
+    await makeLib(
+      tmp,
+      "conjuration",
+      '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
+        '[dependencies.dragon_input]\npath = "../dragon_input"\n',
+    );
+
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n\n' +
+        '[dependencies.dragon_input]\npath = "../../dragon_input_alt"\n',
+    );
+
+    const logs: string[] = [];
+    await bundle(project, { log: (m) => logs.push(m) });
+
+    assertStringIncludes(
+      logs.join("\n"),
+      "using your spec",
+    );
+  });
+});

--- a/utils/bundler.ts
+++ b/utils/bundler.ts
@@ -1,7 +1,12 @@
 import { exists } from "@std/fs";
-import { dirname, join } from "@std/path";
+import { dirname, join, relative, resolve } from "@std/path";
 
-import { readManifest, sourceKind } from "./manifest.ts";
+import {
+  type DependencySpec,
+  readManifest,
+  type SourceKind,
+  sourceKind,
+} from "./manifest.ts";
 import {
   type LockedDependency,
   type Lockfile,
@@ -31,19 +36,248 @@ const context = (
   log,
 });
 
-/** Resolves every dependency from scratch and rewrites the lock + bundle. */
-export const bundle = async (
-  project: Project,
-  options: Options = {},
-): Promise<BundleResult> => {
-  const log = options.log ?? (() => {});
-  const manifest = await readManifest(project.manifestPath);
-  const ctx = context(project, log);
+/**
+ * A dependency's declared identity — source plus pins — used to decide whether
+ * two declarations of the same name agree. Resolved refs are deliberately
+ * excluded: a lock-derived spec carries the pinned sha while a manifest spec
+ * carries the declared intent, and those must compare equal.
+ */
+const specIdentity = (spec: DependencySpec): string => {
+  const kind = sourceKind(spec);
+  return [
+    `${kind}:${spec[kind]}`,
+    spec.tag ?? "",
+    spec.branch ?? "",
+    spec.entrypoint ?? "",
+  ].join("|");
+};
 
-  const dependencies: LockedDependency[] = [];
-  for (const spec of manifest.dependencies) {
-    dependencies.push((await vendorDependency(spec, ctx)).locked);
+const lockedIdentity = (locked: LockedDependency): string =>
+  [
+    locked.source,
+    locked.tag ?? "",
+    locked.branch ?? "",
+    locked.entrypoint ?? "",
+  ].join("|");
+
+/** Reconstructs a resolvable spec from a lock entry (exact ref for remotes). */
+export const lockedToSpec = (locked: LockedDependency): DependencySpec => {
+  const idx = locked.source.indexOf(":");
+  const kind = locked.source.slice(0, idx) as SourceKind;
+  const spec: DependencySpec = {
+    name: locked.name,
+    entrypoint: locked.entrypoint,
+  };
+  spec[kind] = locked.source.slice(idx + 1);
+
+  if (kind === "github" || kind === "git") {
+    spec.ref = locked.ref;
   }
+
+  return spec;
+};
+
+/** Like lockedToSpec, but with the declared pin (tag/branch) instead of the
+ * resolved ref — the spec to use when *updating* the dependency. */
+const lockedToDeclaredSpec = (locked: LockedDependency): DependencySpec => {
+  const spec = lockedToSpec(locked);
+  delete spec.ref;
+  spec.tag = locked.tag;
+  spec.branch = locked.branch;
+  return spec;
+};
+
+type Node = {
+  spec: DependencySpec;
+  topLevel: boolean;
+  via: Set<string>;
+  children: string[];
+  locked?: LockedDependency;
+  sourceDir?: string;
+};
+
+type GraphOptions = {
+  ctx: VendorContext;
+  lock: Lockfile | null;
+  /** Whether a locked entry should be re-fetched instead of reused. `spec` is
+   * the declaration the graph is currently resolving for this name. */
+  refetch: (
+    name: string,
+    locked: LockedDependency,
+    spec: DependencySpec,
+  ) => boolean;
+};
+
+/**
+ * Resolves the full dependency graph — the game's declared dependencies plus
+ * everything they declare in their own `[dependencies]` — into topologically
+ * ordered lock entries (dependencies before their dependents).
+ *
+ * Dedupe is flat: one vendored copy per name. When the same name is declared
+ * twice, the game's top-level declaration wins (with a warning on mismatch);
+ * two disagreeing transitive declarations are an error, resolved by declaring
+ * the package top-level.
+ */
+const resolveGraph = async (
+  manifestDeps: DependencySpec[],
+  { ctx, lock, refetch }: GraphOptions,
+): Promise<LockedDependency[]> => {
+  const nodes = new Map<string, Node>();
+  const queue: string[] = [];
+
+  for (const spec of manifestDeps) {
+    nodes.set(spec.name, {
+      spec,
+      topLevel: true,
+      via: new Set(),
+      children: [],
+    });
+    queue.push(spec.name);
+  }
+
+  const register = (spec: DependencySpec, parent: Node) => {
+    if (!parent.children.includes(spec.name)) {
+      parent.children.push(spec.name);
+    }
+
+    const existing = nodes.get(spec.name);
+    if (!existing) {
+      nodes.set(spec.name, {
+        spec,
+        topLevel: false,
+        via: new Set([parent.spec.name]),
+        children: [],
+      });
+      queue.push(spec.name);
+      return;
+    }
+
+    if (existing.topLevel) {
+      if (specIdentity(existing.spec) !== specIdentity(spec)) {
+        ctx.log(
+          `drenv: '${parent.spec.name}' wants ${spec.name} (${
+            specIdentity(spec).split("|")[0]
+          }) but your drenv.toml declares it — using your spec`,
+        );
+      }
+      return;
+    }
+
+    if (specIdentity(existing.spec) !== specIdentity(spec)) {
+      const [other] = existing.via;
+      throw new Error(
+        `drenv: '${other}' and '${parent.spec.name}' declare conflicting specs for '${spec.name}' — declare it in mygame/drenv.toml to pick one`,
+      );
+    }
+
+    existing.via.add(parent.spec.name);
+  };
+
+  /** Rewrites a library-declared child spec into game-relative terms. */
+  const normalizeChild = (
+    child: DependencySpec,
+    parent: Node,
+  ): DependencySpec => {
+    if (sourceKind(child) !== "path") return child;
+
+    // A relative path in a remote library points at nothing on this machine.
+    if (!parent.sourceDir) {
+      throw new Error(
+        `drenv: '${parent.spec.name}' declares path dependency '${child.name}' — path dependencies can't be transitive from remote sources`,
+      );
+    }
+
+    const absolute = resolve(parent.sourceDir, child.path!);
+    return {
+      ...child,
+      path: (relative(ctx.manifestDir, absolute) || ".").replaceAll("\\", "/"),
+    };
+  };
+
+  while (queue.length > 0) {
+    const name = queue.shift()!;
+    const node = nodes.get(name)!;
+    const locked = lock?.dependencies.find((dep) => dep.name === name);
+
+    if (locked && !refetch(name, locked, node.spec)) {
+      node.locked = locked;
+
+      // Reused entries re-derive their children from the lock graph.
+      for (const child of lock!.dependencies) {
+        if (child.via?.includes(name)) {
+          register(lockedToDeclaredSpec(child), node);
+        }
+      }
+      continue;
+    }
+
+    const result = await vendorDependency(node.spec, ctx);
+    node.locked = result.locked;
+    node.sourceDir = result.sourceDir;
+
+    for (const child of result.dependencies) {
+      register(normalizeChild(child, node), node);
+    }
+  }
+
+  // Post-order DFS from the top-level roots: children (dependencies) are
+  // emitted before their parents, so the bundle file requires them in order.
+  const ordered: LockedDependency[] = [];
+  const state = new Map<string, "visiting" | "done">();
+
+  const visit = (name: string, chain: string[]) => {
+    const status = state.get(name);
+    if (status === "done") return;
+    if (status === "visiting") {
+      throw new Error(
+        `drenv: dependency cycle: ${[...chain, name].join(" -> ")}`,
+      );
+    }
+
+    state.set(name, "visiting");
+    const node = nodes.get(name)!;
+    for (const child of node.children) {
+      visit(child, [...chain, name]);
+    }
+    state.set(name, "done");
+
+    ordered.push({
+      ...node.locked!,
+      via: node.topLevel ? undefined : [...node.via].sort(),
+    });
+  };
+
+  for (const spec of manifestDeps) {
+    visit(spec.name, []);
+  }
+
+  return ordered;
+};
+
+/** Removes vendor directories of packages that fell out of the graph. */
+const removeOrphans = async (
+  project: Project,
+  oldLock: Lockfile | null,
+  dependencies: LockedDependency[],
+): Promise<void> => {
+  if (!oldLock) return;
+
+  const live = new Set(dependencies.map((dep) => dep.name));
+  for (const dep of oldLock.dependencies) {
+    if (!live.has(dep.name)) {
+      await Deno.remove(join(project.mygame, "vendor", dep.name), {
+        recursive: true,
+      }).catch(() => {});
+    }
+  }
+};
+
+const finalize = async (
+  project: Project,
+  dependencies: LockedDependency[],
+  oldLock: Lockfile | null,
+): Promise<BundleResult> => {
+  await removeOrphans(project, oldLock, dependencies);
 
   const lock: Lockfile = {
     lockfile_version: LOCKFILE_VERSION,
@@ -58,11 +292,31 @@ export const bundle = async (
   return { lock, needsRequireLine: await needsRequireLine(project) };
 };
 
+/** Resolves every dependency from scratch and rewrites the lock + bundle. */
+export const bundle = async (
+  project: Project,
+  options: Options = {},
+): Promise<BundleResult> => {
+  const log = options.log ?? (() => {});
+  const manifest = await readManifest(project.manifestPath);
+  const ctx = context(project, log);
+  const oldLock = await readLock(project.lockPath);
+
+  const dependencies = await resolveGraph(manifest.dependencies, {
+    ctx,
+    lock: oldLock,
+    refetch: () => true,
+  });
+
+  return finalize(project, dependencies, oldLock);
+};
+
 /**
  * Brings the vendor directory in line with the existing lock without a full
  * re-resolve: path deps are always re-synced (they are mutable), remote deps
  * are only re-fetched when missing or when their checksum no longer matches.
- * Falls back to a full {@link bundle} when the lock is missing or stale.
+ * Transitive dependencies are restored from their lock entries. Falls back to
+ * a full {@link bundle} when the lock is missing or stale.
  *
  * With `frozen`, the lock is treated as authoritative: a missing/stale lock or
  * a remote dependency whose fetched contents don't match the recorded checksum
@@ -90,18 +344,21 @@ export const reconcile = async (
   const manifest = await readManifest(project.manifestPath);
   const ctx = context(project, log);
 
-  for (const spec of manifest.dependencies) {
-    const locked = lock.dependencies.find((dep) => dep.name === spec.name);
-    const dir = join(project.mygame, "vendor", spec.name);
+  for (const locked of lock.dependencies) {
+    // Top-level entries use the manifest's spec; transitive entries are
+    // reconstructed from the lock (pinned to their exact resolved ref).
+    const spec = manifest.dependencies.find((d) => d.name === locked.name) ??
+      lockedToSpec(locked);
+    const dir = join(project.mygame, "vendor", locked.name);
 
     if (sourceKind(spec) === "path") {
       await vendorDependency(spec, ctx);
-    } else if (!await matches(dir, locked?.integrity)) {
+    } else if (!await matches(dir, locked.integrity)) {
       await vendorDependency(spec, ctx);
 
-      if (frozen && !await matches(dir, locked?.integrity)) {
+      if (frozen && !await matches(dir, locked.integrity)) {
         throw new Error(
-          `drenv: dependency '${spec.name}' does not match the lockfile — run \`drenv bundle\``,
+          `drenv: dependency '${locked.name}' does not match the lockfile — run \`drenv bundle\``,
         );
       }
     }
@@ -114,9 +371,10 @@ export const reconcile = async (
 };
 
 /**
- * Re-resolves a single dependency to its latest, keeping every other dependency
- * at its currently locked revision. Any manifest dependency not yet in the lock
- * is resolved too, so the lock and bundle stay complete.
+ * Re-resolves a single dependency to its latest, keeping every other
+ * dependency at its currently locked revision. Anything not yet locked — a new
+ * dependency, or one the updated package newly declares — is resolved too, and
+ * packages that fell out of the graph are dropped.
  */
 export const updateDependency = async (
   project: Project,
@@ -127,37 +385,33 @@ export const updateDependency = async (
   const manifest = await readManifest(project.manifestPath);
 
   if (!manifest.dependencies.some((dep) => dep.name === name)) {
+    const oldLock = await readLock(project.lockPath);
+    const locked = oldLock?.dependencies.find((dep) => dep.name === name);
+    if (locked?.via?.length) {
+      throw new Error(
+        `drenv: '${name}' is a transitive dependency (via ${
+          locked.via.join(", ")
+        }) — update its parent, or declare it in mygame/drenv.toml to manage it directly`,
+      );
+    }
     throw new Error(
       `drenv: no dependency named '${name}' in ${project.manifestPath}`,
     );
   }
 
-  const existing = await readLock(project.lockPath);
   const ctx = context(project, log);
+  const oldLock = await readLock(project.lockPath);
 
-  const dependencies: LockedDependency[] = [];
-  for (const spec of manifest.dependencies) {
-    const locked = existing?.dependencies.find((dep) => dep.name === spec.name);
+  const dependencies = await resolveGraph(manifest.dependencies, {
+    ctx,
+    lock: oldLock,
+    // Re-fetch the target, plus any entry whose declared spec no longer
+    // matches what was locked (e.g. a parent update changed a child's pin).
+    refetch: (depName, locked, spec) =>
+      depName === name || specIdentity(spec) !== lockedIdentity(locked),
+  });
 
-    // Re-resolve the target, and anything not yet locked; reuse the rest.
-    if (spec.name === name || !locked) {
-      dependencies.push((await vendorDependency(spec, ctx)).locked);
-    } else {
-      dependencies.push(locked);
-    }
-  }
-
-  const lock: Lockfile = {
-    lockfile_version: LOCKFILE_VERSION,
-    manifest_digest: await fileDigest(project.manifestPath),
-    dependencies,
-  };
-
-  await writeLock(project.lockPath, lock);
-  await writeBundleFile(project.mygame, lock);
-  await ensureVendorIgnore(project.mygame);
-
-  return { lock, needsRequireLine: await needsRequireLine(project) };
+  return finalize(project, dependencies, oldLock);
 };
 
 const matches = async (

--- a/utils/lockfile.ts
+++ b/utils/lockfile.ts
@@ -8,6 +8,13 @@ export type LockedDependency = {
   ref?: string;
   require: string[];
   integrity?: string;
+  /** Names of the dependencies that requested this one; absent = top-level. */
+  via?: string[];
+  /** The declared tag/branch pin, kept so the dep can be re-resolved later. */
+  tag?: string;
+  branch?: string;
+  /** A consumer-declared entrypoint override, kept for lock-based re-fetches. */
+  entrypoint?: string;
 };
 
 export type Lockfile = {
@@ -43,6 +50,10 @@ export const writeLock = async (
     ...(dep.ref ? { ref: dep.ref } : {}),
     require: dep.require,
     ...(dep.integrity ? { integrity: dep.integrity } : {}),
+    ...(dep.via?.length ? { via: dep.via } : {}),
+    ...(dep.tag ? { tag: dep.tag } : {}),
+    ...(dep.branch ? { branch: dep.branch } : {}),
+    ...(dep.entrypoint ? { entrypoint: dep.entrypoint } : {}),
   }));
 
   const body = stringify({

--- a/utils/sources/git.ts
+++ b/utils/sources/git.ts
@@ -1,6 +1,7 @@
 import type { DependencySpec } from "../manifest.ts";
 import { treeDigest } from "../integrity.ts";
 import {
+  readLibraryDependencies,
   stageIntoVendor,
   type VendorContext,
   vendorDir,
@@ -108,8 +109,12 @@ export const vendorGit = async (
         ref: sha || undefined,
         require: [require],
         integrity: await treeDigest(vendorDir(ctx, spec.name)),
+        tag: spec.tag,
+        branch: spec.branch,
+        entrypoint: spec.entrypoint,
       },
       staged: true,
+      dependencies: await readLibraryDependencies(tmp),
     };
   } finally {
     await Deno.remove(tmp, { recursive: true }).catch(() => {});

--- a/utils/sources/github.ts
+++ b/utils/sources/github.ts
@@ -5,6 +5,7 @@ import { configure, ZipReaderStream } from "@zip-js/zip-js";
 import type { DependencySpec } from "../manifest.ts";
 import { treeDigest } from "../integrity.ts";
 import {
+  readLibraryDependencies,
   stageIntoVendor,
   type VendorContext,
   vendorDir,
@@ -100,8 +101,12 @@ export const vendorGithub = async (
         ref: sha ?? downloadRef,
         require: [require],
         integrity: await treeDigest(vendorDir(ctx, spec.name)),
+        tag: spec.tag,
+        branch: spec.branch,
+        entrypoint: spec.entrypoint,
       },
       staged: true,
+      dependencies: await readLibraryDependencies(staging),
     };
   } finally {
     await Deno.remove(staging, { recursive: true }).catch(() => {});

--- a/utils/sources/path.ts
+++ b/utils/sources/path.ts
@@ -3,6 +3,7 @@ import { resolve } from "@std/path";
 
 import type { DependencySpec } from "../manifest.ts";
 import {
+  readLibraryDependencies,
   stageIntoVendor,
   type VendorContext,
   type VendorResult,
@@ -39,7 +40,10 @@ export const vendorPath = async (
       name: spec.name,
       source: `path:${spec.path}`,
       require: [require],
+      entrypoint: spec.entrypoint,
     },
     staged,
+    dependencies: await readLibraryDependencies(source),
+    sourceDir: source,
   };
 };

--- a/utils/sources/resolve.ts
+++ b/utils/sources/resolve.ts
@@ -2,7 +2,11 @@ import { exists } from "@std/fs";
 import { join } from "@std/path";
 import { parse } from "@std/toml";
 
-import type { PackageSpec } from "../manifest.ts";
+import {
+  type DependencySpec,
+  type PackageSpec,
+  parseManifest,
+} from "../manifest.ts";
 import type { LockedDependency } from "../lockfile.ts";
 import { copyTree } from "../copy-tree.ts";
 import { filesetDigest, type FilesetPart } from "../integrity.ts";
@@ -21,6 +25,28 @@ export type VendorResult = {
   locked: LockedDependency;
   /** False when an up-to-date vendor directory let us skip the copy. */
   staged: boolean;
+  /** Dependencies the library itself declares in its root drenv.toml. */
+  dependencies: DependencySpec[];
+  /**
+   * Where the library's source tree lives, when it persists past vendoring —
+   * set for path deps only. Used to resolve their relative path children.
+   */
+  sourceDir?: string;
+};
+
+/**
+ * The `[dependencies]` a library declares in its own root `drenv.toml`.
+ * Missing or unparsable manifests yield none, matching `[package]` handling.
+ */
+export const readLibraryDependencies = async (
+  dir: string,
+): Promise<DependencySpec[]> => {
+  try {
+    const text = await Deno.readTextFile(join(dir, "drenv.toml"));
+    return parseManifest(text).dependencies;
+  } catch {
+    return [];
+  }
 };
 
 /** Absolute path of a dependency's vendor directory. */

--- a/utils/sources/url.ts
+++ b/utils/sources/url.ts
@@ -47,7 +47,10 @@ export const vendorUrl = async (
       source: `url:${url}`,
       require: [vendorRequire(spec.name, filename)],
       integrity: await treeDigest(dest),
+      entrypoint: spec.entrypoint,
     },
     staged: true,
+    // A url dep is a single file — it can't declare dependencies of its own.
+    dependencies: [],
   };
 };


### PR DESCRIPTION
Lets a library declare its own `[dependencies]` (in the `drenv.toml` at its repo root, same table shape games use) and have drenv resolve the whole graph — the prerequisite for Conjuration depending on dragon_input.

## Resolution model

- **Discovery**: each source already stages the fetched tree; the library's `[dependencies]` are read there and resolved iteratively until the graph is complete.
- **Flat dedupe**: one vendored copy per package name (`vendor/<name>`) — forced by DragonRuby's game-dir-relative requires and asset paths.
- **Conflict policy** (as discussed):
  - Game's top-level declaration **wins**; drenv warns when a library wanted something different.
  - Two libraries disagreeing with no top-level arbiter → **error**, resolved by declaring the package in `mygame/drenv.toml`.
  - Identity = source + declared pins + entrypoint (resolved shas deliberately excluded so lock-derived and manifest specs compare equal).
- **Require order**: the generated `drenv_bundle.rb` requires dependencies before their dependents (post-order DFS). Cycles → error with the cycle path.
- **Transitive `path:` deps** only under `path:` parents (local side-by-side dev), resolved relative to the parent's source and rewritten game-relative; under remote parents → error.

## Lockfile (additive, still v1)

Entries gain `via` (requesting parents), declared `tag`/`branch` pins, and `entrypoint` overrides. That makes the lock the source of truth for the graph:
- `reconcile`/`--frozen` now iterate the **lock** (not just the manifest), restoring missing transitive deps at their exact locked refs.
- **Sticky locks hold through the graph**: updating one package never moves another's locked ref. `update <parent>` re-resolves the parent, re-resolves any child whose declared spec changed, picks up new children, and prunes orphans (lock + vendor dir).
- `update <transitive>` errors with its parents named (manage it by declaring it top-level).
- `list` annotates transitive deps with `via <parent>`.

## Tests

10 new offline tests (path fixtures + local git repos): flat resolution with `via` + require order + transitive `include` assets flowing through; top-level-wins (content + warning); transitive conflict error; path-under-remote error; cycle error; **graph stickiness** (updating an unrelated dep or the parent itself doesn't move a locked transitive ref even after upstream advances); lock-based restore of a missing transitive vendor dir at the locked rev (not upstream HEAD); orphan pruning. Full suite: 42 passing. Also verified live via the CLI (`bundle` + `list`).

## Notes

- Old locks (no `via`/pins) still parse; the first re-resolve writes the new fields. One-time effect: pinned deps re-fetch once (to the same pin) because their lock entries predate the recorded pins.
- Residual (unchanged): editing `drenv.toml` by hand and running `drenv run` still triggers a full re-resolve via the manifest-digest fallback.

New capability → **minor** (0.15.0).