### PR TITLE
feat: graph-aware outdated and direct transitive updates

### DIFF
--- a/commands/outdated.ts
+++ b/commands/outdated.ts
@@ -3,6 +3,7 @@ import { exists } from "@std/fs";
 import { findProject } from "../utils/project.ts";
 import { readManifest, sourceKind } from "../utils/manifest.ts";
 import { readLock } from "../utils/lockfile.ts";
+import { lockedToDeclaredSpec } from "../utils/bundler.ts";
 import { remoteRef } from "../utils/sources/mod.ts";
 
 const shortRef = (ref: string): string => ref.slice(0, 7);
@@ -23,17 +24,27 @@ export default async function outdated() {
     throw new Error("drenv: no lockfile — run `drenv bundle` first");
   }
 
-  const stale: { name: string; from: string; to: string }[] = [];
+  const stale: { name: string; from: string; to: string; via: string }[] = [];
 
-  for (const spec of manifest.dependencies) {
+  // The lock holds the whole graph, transitive deps included. Top-level names
+  // check against the manifest's spec; transitive ones against the declared
+  // pin recorded in the lock.
+  for (const locked of lock.dependencies) {
+    const spec = manifest.dependencies.find((d) => d.name === locked.name) ??
+      lockedToDeclaredSpec(locked);
+
     // path/url sources aren't revision-tracked, so there's nothing to compare.
     if (sourceKind(spec) === "path" || sourceKind(spec) === "url") continue;
 
-    const locked = lock.dependencies.find((dep) => dep.name === spec.name);
     const current = await remoteRef(spec);
 
-    if (locked?.ref && current && current !== locked.ref) {
-      stale.push({ name: spec.name, from: locked.ref, to: current });
+    if (locked.ref && current && current !== locked.ref) {
+      stale.push({
+        name: locked.name,
+        from: locked.ref,
+        to: current,
+        via: locked.via?.length ? `  via ${locked.via.join(", ")}` : "",
+      });
     }
   }
 
@@ -46,7 +57,7 @@ export default async function outdated() {
     console.log(
       `  ${row.name.padEnd(nameWidth)}  ${shortRef(row.from)} → ${
         shortRef(row.to)
-      }`,
+      }${row.via}`,
     );
   }
   console.log("\nRun `drenv update [name]` to upgrade.");

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -79,11 +79,15 @@ the rest stay pinned to their locked revisions; without one, everything is
 re-resolved. Pinned deps (a `tag` or `ref`) don't move; floating ones (a
 `branch`, or no pin) advance to the newest commit.
 
+The name may also be a transitive dependency — it's re-resolved at the pin its
+parent declared, without touching anything else.
+
 ### `drenv outdated`
 
 Checks each remote dependency's upstream against the lockfile and lists the ones
 whose tracked revision has moved on, so you can decide what to `drenv update`.
-Path and URL sources aren't revision-tracked and are skipped.
+Transitive dependencies are checked too (annotated `via <parent>`). Path and URL
+sources aren't revision-tracked and are skipped.
 
 ### `drenv bundle`
 

--- a/utils/bundler-nested.test.ts
+++ b/utils/bundler-nested.test.ts
@@ -307,13 +307,17 @@ describe("bundler (nested dependencies)", () => {
     );
   });
 
-  it("names the parents when updating a transitive dep directly", async () => {
-    await makeLib(tmp, "dragon_input");
+  it("updates a transitive dep directly, at its declared pin", async () => {
+    const timer = await makeLib(tmp, "timer");
+    await git(["init", "-b", "main"], timer);
+    await git(["add", "."], timer);
+    await git(["commit", "-m", "v1"], timer);
+
     await makeLib(
       tmp,
       "conjuration",
       '[package]\nroot = "lib"\nentrypoint = "conjuration.rb"\n\n' +
-        '[dependencies.dragon_input]\npath = "../dragon_input"\n',
+        `[dependencies.timer]\ngit = "${timer.replaceAll("\\", "/")}"\n`,
     );
 
     const project = await makeGame(
@@ -321,11 +325,36 @@ describe("bundler (nested dependencies)", () => {
       '[dependencies.conjuration]\npath = "../../conjuration"\n',
     );
     await bundle(project);
+    const before = (await readLock(project.lockPath))?.dependencies.find(
+      (d) => d.name === "timer",
+    );
+    assertExists(before?.ref);
+
+    await Deno.writeTextFile(join(timer, "lib", "timer.rb"), "# v2\n");
+    await git(["add", "."], timer);
+    await git(["commit", "-m", "v2"], timer);
+
+    await updateDependency(project, "timer");
+
+    const after = (await readLock(project.lockPath))?.dependencies.find(
+      (d) => d.name === "timer",
+    );
+    assert(after?.ref && after.ref !== before?.ref, "timer ref should move");
+    assertEquals(after?.via, ["conjuration"]);
+  });
+
+  it("rejects updating a name that is neither declared nor locked", async () => {
+    await makeLib(tmp, "conjuration");
+    const project = await makeGame(
+      tmp,
+      '[dependencies.conjuration]\npath = "../../conjuration"\n',
+    );
+    await bundle(project);
 
     await assertRejects(
-      () => updateDependency(project, "dragon_input"),
+      () => updateDependency(project, "nope"),
       Error,
-      "via conjuration",
+      "no dependency named 'nope'",
     );
   });
 

--- a/utils/bundler.ts
+++ b/utils/bundler.ts
@@ -79,7 +79,9 @@ export const lockedToSpec = (locked: LockedDependency): DependencySpec => {
 
 /** Like lockedToSpec, but with the declared pin (tag/branch) instead of the
  * resolved ref — the spec to use when *updating* the dependency. */
-const lockedToDeclaredSpec = (locked: LockedDependency): DependencySpec => {
+export const lockedToDeclaredSpec = (
+  locked: LockedDependency,
+): DependencySpec => {
   const spec = lockedToSpec(locked);
   delete spec.ref;
   spec.tag = locked.tag;
@@ -372,9 +374,11 @@ export const reconcile = async (
 
 /**
  * Re-resolves a single dependency to its latest, keeping every other
- * dependency at its currently locked revision. Anything not yet locked — a new
- * dependency, or one the updated package newly declares — is resolved too, and
- * packages that fell out of the graph are dropped.
+ * dependency at its currently locked revision. The target may be transitive —
+ * the graph walk reaches it through its (reused) parents and re-resolves it at
+ * its declared pin. Anything not yet locked — a new dependency, or one the
+ * updated package newly declares — is resolved too, and packages that fell out
+ * of the graph are dropped.
  */
 export const updateDependency = async (
   project: Project,
@@ -383,24 +387,20 @@ export const updateDependency = async (
 ): Promise<BundleResult> => {
   const log = options.log ?? (() => {});
   const manifest = await readManifest(project.manifestPath);
+  const oldLock = await readLock(project.lockPath);
 
-  if (!manifest.dependencies.some((dep) => dep.name === name)) {
-    const oldLock = await readLock(project.lockPath);
-    const locked = oldLock?.dependencies.find((dep) => dep.name === name);
-    if (locked?.via?.length) {
-      throw new Error(
-        `drenv: '${name}' is a transitive dependency (via ${
-          locked.via.join(", ")
-        }) — update its parent, or declare it in mygame/drenv.toml to manage it directly`,
-      );
-    }
+  const known = manifest.dependencies.some((dep) => dep.name === name) ||
+    oldLock?.dependencies.some(
+      (dep) => dep.name === name && dep.via?.length,
+    );
+
+  if (!known) {
     throw new Error(
       `drenv: no dependency named '${name}' in ${project.manifestPath}`,
     );
   }
 
   const ctx = context(project, log);
-  const oldLock = await readLock(project.lockPath);
 
   const dependencies = await resolveGraph(manifest.dependencies, {
     ctx,


### PR DESCRIPTION
Completes the nested-dependency work (step 3 of 3): the day-to-day commands now understand the graph.

## `drenv outdated`
Walks the **lock** (the full graph) instead of just the manifest. Transitive deps are checked against upstream at the pin their parent declared (recorded in the lock since #48), and flagged with `via <parent>`:

```
  timer  727916e → b21b1e0  via conj
```

## `drenv update <name>` accepts transitive names
Previously errored with guidance; now the graph walk reaches the target through its reused parents and re-resolves it at its declared pin — **moving nothing else** (sticky locks hold). Unknown names still error.

## Verified
- Tests: direct transitive update moves the target's ref and preserves its `via` edge; unknown-name rejection. Full suite: 42 passing.
- Live CLI loop: `bundle` → upstream advances → `outdated` flags the transitive with `via` → `update timer` → `outdated` clean → `list` shows the edge.

New capability → minor (0.16.0).